### PR TITLE
nucleotide count: adds strand validation to tests

### DIFF
--- a/nucleotide-count/nucleotide-count_test.hs
+++ b/nucleotide-count/nucleotide-count_test.hs
@@ -34,6 +34,8 @@ countTests =
     1 @=? count 'T' "GGGGGTAACCCGG"
   , testCase "validates nucleotides" $
     assertError "invalid nucleotide 'X'" $ count 'X' "GACT"
+  , testCase "validates strand" $
+    assertError "invalid nucleotide 'Y'" $ count 'G' "GACYT"
   ]
 
 nucleotideCountTests :: [Test]
@@ -48,4 +50,6 @@ nucleotideCountTests =
     fromList [('A', 20), ('T', 21), ('C', 12), ('G', 17)] @=?
     nucleotideCounts ("AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAA" ++
                       "GAGTGTCTGATAGCAGC")
+  , testCase "validates strand" $
+    assertError "invalid nucleotide 'P'" $ nucleotideCounts "GPAC"
   ]


### PR DESCRIPTION
This pull request addresses #58.

The previous tests asserted that, e.g., `count 'X' "ACGT"` would throw an error indicating that `'X'` is not a valid nucleotide. The example implementation performed the same error checking on the strand being counted and on the argument to `nucleotideCounds`, but the tests did not check for this behavior. This PR implements tests that do.