### PR TITLE
Added attribution link to the source of the quicksort example in ABOUT.md

### DIFF
--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -32,6 +32,7 @@ quicksort (x:xs) =
         biggerSorted  = quicksort [a | a <- xs, a > x]
     in  smallerSorted ++ [x] ++ biggerSorted
 ```
+[(source)](http://learnyouahaskell.com/recursion#quick-sort)
 
 In addition, Haskell is standardized and has multiple high-quality
 implementations, some of which produce standalone native binaries.


### PR DESCRIPTION
I realized after the fact that I'd gotten the Quicksort example from "Learn You A Haskell", so I added a link.