### PR TITLE
gigasecond: fix use of deprecated package

### DIFF
--- a/gigasecond/gigasecond_test.hs
+++ b/gigasecond/gigasecond_test.hs
@@ -3,13 +3,12 @@ import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), Counts(..))
 import System.Exit (ExitCode(..), exitWith)
 import Gigasecond (fromDay)
 import Data.Time.Clock (UTCTime)
-import System.Locale (iso8601DateFormat)
 #if __GLASGOW_HASKELL__ >= 710
-import Data.Time.Format (TimeLocale, ParseTime, parseTimeOrError, defaultTimeLocale)
+import Data.Time.Format (TimeLocale, ParseTime, parseTimeOrError, defaultTimeLocale, iso8601DateFormat)
 readTime :: ParseTime t => TimeLocale -> String -> String -> t
 readTime = parseTimeOrError True
 #else
-import System.Locale (defaultTimeLocale)
+import System.Locale (defaultTimeLocale, iso8601DateFormat)
 import Data.Time.Format (readTime)
 #endif
 


### PR DESCRIPTION
Apparently `System.Locale` get deprecated on haskell 7.10 and moved to the package `old-locale-1.0.0.7`.

And this change will use reuse the function provided by `Data.Time.Format`

Ref: https://github.com/exercism/xhaskell/issues/85#issuecomment-191382840