### PR TITLE
largest-series-product: Do not test digits/slices

### DIFF
--- a/largest-series-product/example.hs
+++ b/largest-series-product/example.hs
@@ -1,4 +1,4 @@
-module Series (digits, slices, largestProduct) where
+module Series (largestProduct) where
 import Data.Char (digitToInt)
 import Data.List (tails)
 

--- a/largest-series-product/largest-series-product_test.hs
+++ b/largest-series-product/largest-series-product_test.hs
@@ -1,6 +1,6 @@
 import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), Counts(..))
 import System.Exit (ExitCode(..), exitWith)
-import Series (digits, slices, largestProduct)
+import Series (largestProduct)
 
 exitProperly :: IO Counts -> IO ()
 exitProperly m = do
@@ -15,9 +15,6 @@ main = exitProperly $ runTestTT $ TestList
   [ TestList seriesTests ]
 
 -- Allow implementations that work with Integral to compile without warning
-ints :: [Int] -> [Int]
-ints = id
-
 int :: Int -> Maybe Int
 int = Just
 
@@ -26,15 +23,7 @@ intNothing = Nothing
 
 seriesTests :: [Test]
 seriesTests = map TestCase
-  [ ints [0..9] @=? digits ['0'..'9']
-  , ints [9,8..0] @=? digits ['9','8'..'0']
-  , ints [8,7..4] @=? digits ['8','7'..'4']
-  , ints [9, 3, 6, 9, 2, 3, 4, 6, 8] @=? digits "936923468"
-  , map ints [[9, 8], [8, 2], [2, 7], [7, 3], [3, 4], [4, 6], [6, 3]] @=?
-    slices 2 "98273463"
-  , map ints [[9, 8, 2], [8, 2, 3], [2, 3, 4], [3, 4, 7]] @=?
-    slices 3 "982347"
-  , int 72 @=? largestProduct 2 "0123456789"
+  [ int 72 @=? largestProduct 2 "0123456789"
   , int 2 @=? largestProduct 2 "12"
   , int 9 @=? largestProduct 2 "19"
   , int 48 @=? largestProduct 2 "576802143"


### PR DESCRIPTION
The digits and slices functions are internal implementation details and
thus the test case for the largest-series-product problem should not be
concerned with testing them. The series tests could potentially be moved
to the series exercise (already implemented by this track).

Their presence may cause students to falsely think that their solution
has to use these two functions, instead of the alternative
implementation of only iterating through the digits once.

If it is desired to give hints on how to approach this problem (which
was one advantage of having the digits and slices tests), then consider
including a hints file and/or directory in the largest-series-product
directory.

This PR arises from discussion in
https://github.com/exercism/x-common/issues/192