### PR TITLE
SETUP.md: link to exercism Haskell page not help.exercism.io

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -1,5 +1,5 @@
 Check out [Exercism
-Help](http://help.exercism.io/getting-started-with-haskell.html) for
+Help](http://exercism.io/languages/haskell) for
 instructions to get started writing Haskell.
 
 ## Running Tests


### PR DESCRIPTION
help.exercism.io was deprecated sometime around December 2015.

Closes #104