### PR TITLE
rename point-mutations to hamming

### DIFF
--- a/config.json
+++ b/config.json
@@ -13,7 +13,7 @@
     "bob",
     "sum-of-multiples",
     "strain",
-    "point-mutations",
+    "hamming",
     "space-age",
     "anagram",
     "nucleotide-count",

--- a/exercises/hamming/example.hs
+++ b/exercises/hamming/example.hs
@@ -1,0 +1,4 @@
+module Hamming (distance) where
+
+distance :: String -> String -> Int
+distance a b = sum . map fromEnum $ zipWith (/=) a b

--- a/exercises/hamming/hamming_test.hs
+++ b/exercises/hamming/hamming_test.hs
@@ -1,6 +1,6 @@
 import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), Counts(..))
 import System.Exit (ExitCode(..), exitWith)
-import DNA (hammingDistance)
+import Hamming (distance)
 
 exitProperly :: IO Counts -> IO ()
 exitProperly m = do
@@ -17,13 +17,13 @@ main = exitProperly $ runTestTT $ TestList
 hammingDistanceTests :: [Test]
 hammingDistanceTests =
   [ testCase "no difference between empty strands" $
-    0 @=? hammingDistance "" ""
+    0 @=? distance "" ""
   , testCase "no difference between identical strands" $
-    0 @=? hammingDistance "GGACTGA" "GGACTGA"
+    0 @=? distance "GGACTGA" "GGACTGA"
   , testCase "complete hamming distance in small strand" $
-    3 @=? hammingDistance "ACT" "GGA"
+    3 @=? distance "ACT" "GGA"
   , testCase "small hamming distance in middle somewhere" $
-    1 @=? hammingDistance "GGACG" "GGTCG"
+    1 @=? distance "GGACG" "GGTCG"
   , testCase "larger distance" $
-    2 @=? hammingDistance "ACCAGGG" "ACTATGG"
+    2 @=? distance "ACCAGGG" "ACTATGG"
   ]

--- a/exercises/point-mutations/example.hs
+++ b/exercises/point-mutations/example.hs
@@ -1,4 +1,0 @@
-module DNA (hammingDistance) where
-
-hammingDistance :: String -> String -> Int
-hammingDistance a b = sum . map fromEnum $ zipWith (/=) a b


### PR DESCRIPTION
point-mutations was deprecated in favor of hamming a while ago (to make
it more generic, since it really was just about Hamming distance rather
than specifically about biological applications)

Since the module is now named Hamming, the function hammingDistance is
renamed to distance so as to not be repetitive (Hamming.distance versus
Hamming.hammingDistance)

Fixes #95