### PR TITLE
binary: Expand invalid input tests

### DIFF
--- a/exercises/binary/binary_test.hs
+++ b/exercises/binary/binary_test.hs
@@ -24,5 +24,8 @@ binaryTests = map TestCase
   , 26 @=? toDecimal "11010"
   , 1128 @=? toDecimal "10001101000"
   , 0 @=? toDecimal "carrot"
-  , 0 @=? toDecimal "carrot123"
+  , 0 @=? toDecimal "foo101"
+  , 0 @=? toDecimal "101bar"
+  , 0 @=? toDecimal "101baz010"
+  , 0 @=? toDecimal "22"
   ]


### PR DESCRIPTION
"carrot123" was too coarse-grained. We'd instead like to test alphabetic
characters at the beginning, middle, and end of otherwise-valid numbers.
The test for digits such as 2 should also come in a separate test.

Closes #111