### PR TITLE
travis: Test ghc 8.0.1 (and avoid some compiler warnings on 8.0.1)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ addons:
       - ghc-7.6.3
       - ghc-7.8.4
       - ghc-7.10.3
+      - ghc-8.0.1
       - cabal-install-1.22
 env:
   global:
@@ -21,6 +22,7 @@ env:
     - GHCVER=7.6.3
     - GHCVER=7.8.4
     - GHCVER=7.10.3
+    - GHCVER=8.0.1
 cache:
   directories:
     - '$HOME/.ghc'

--- a/exercises/binary-search-tree/example.hs
+++ b/exercises/binary-search-tree/example.hs
@@ -38,7 +38,7 @@ bstRight (Node _ _ r) = Just r
 empty :: BST a
 empty = Tip
 
-singleton :: Ord a => a -> BST a
+singleton :: a -> BST a
 singleton x = Node empty x empty
 
 insert :: Ord a => a -> BST a -> BST a

--- a/exercises/custom-set/example.hs
+++ b/exercises/custom-set/example.hs
@@ -27,7 +27,7 @@ data CustomSet a
   = Tip
   | Bin {-# UNPACK #-} !Int !a !(CustomSet a) !(CustomSet a)
 
-instance (Ord a, Eq a) => Eq (CustomSet a) where
+instance (Ord a) => Eq (CustomSet a) where
   a == b = size a == size b && a `isSubsetOf` b
 
 instance Show a => Show (CustomSet a) where
@@ -47,13 +47,13 @@ size :: CustomSet a -> Int
 size Tip              = 0
 size (Bin s _a _l _r) = s
 
-singleton :: Ord a => a -> CustomSet a
+singleton :: a -> CustomSet a
 singleton x = Bin 1 x Tip Tip
 
 toList :: CustomSet a -> [a]
 toList = F.toList
 
-empty :: Ord a => CustomSet a
+empty :: CustomSet a
 empty = Tip
 
 fromList :: Ord a => [a] -> CustomSet a


### PR DESCRIPTION
It's a prerelease version, but it's likely to be good to start testing
against it now.

Two commits are needed to avoid compiler warnings on 8.0.1 (and thus errors since we use `-Werror`). The errors that would appear are noted in the commit message.