### PR TITLE
travis: Explain why we use hvr-ghc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,8 @@
+# The Travis docs (https://docs.travis-ci.com/user/languages/haskell)
+# suggest that we use `language: haskell` and `ghc:` to specify GHC versions.
+# However, as of this writing, Travis only supported versions up to 7.8.
+# If Travis supports all versions we would like to test, then we could switch.
+# Until then, we use the https://github.com/hvr/multi-ghc-travis setup.
 language: c
 sudo: false
 addons:


### PR DESCRIPTION
I submitted #121 to try to see why we didn't use `language: haskell`.
I got my answer, and now it's a good idea to record why so that we will
know when we are able to re-evaluate our options.

Closes #123.