### PR TITLE
Adds more cases to phone-number tests

### DIFF
--- a/exercises/phone-number/phone-number_test.hs
+++ b/exercises/phone-number/phone-number_test.hs
@@ -20,10 +20,14 @@ numberTests :: [Test]
 numberTests =
   [ testCase "cleans number" $
     "1234567890" @=? number "(123) 456-7890"
+  , testCase "cleans another number" $
+    "6125551212" @=? number "(612) 555-1212"
   , testCase "cleans number with dots" $
     "1234567890" @=? number "123.456.7890"
+  , testCase "cleans another number with dots" $
+    "9187654321" @=? number "918.765.4321"
   , testCase "valid when 11 digits and first is 1" $
-    "1234567890" @=? number "11234567890"
+    "2468013579" @=? number "12468013579"
   , testCase "invalid when 11 digits" $
     "0000000000" @=? number "21234567890"
   , testCase "invalid when 9 digits" $
@@ -35,21 +39,31 @@ numberTests =
   , testCase "invalid when no digits present" $
     "0000000000" @=? number " (-) "
   , testCase "valid with leading characters" $
-    "1234567890" @=? number "my number is 123 456 7890"
+    "2358132134" @=? number "my number is 235 813 2134"
   , testCase "valid with trailing characters" $
-    "1234567890" @=? number "123 456 7890 - bob"
+    "9876543210" @=? number "987 654 3210 - bob"
+  , testCase "valid amidst text and punctuation" $
+    "4158880000" @=? number "Here it is: 415-888-0000. Thanks!"
   ]
 
 areaCodeTests :: [Test]
 areaCodeTests =
   [ testCase "area code" $
     "123" @=? areaCode "1234567890"
+  , testCase "area code with parentheses" $
+    "612" @=? areaCode "(612) 555-1212"
+  , testCase "area code with leading characters" $
+    "235" @=? areaCode "my number is 235 813 2134"
+  , testCase "invalid area code" $
+    "000" @=? areaCode " (-) "
   ]
 
 prettyPrintTests :: [Test]
 prettyPrintTests =
   [ testCase "pretty print" $
     "(123) 456-7890" @=? prettyPrint "1234567890"
-  , testCase "pretty print with full us phone number" $
-    "(123) 456-7890" @=? prettyPrint "11234567890"
+  , testCase "pretty print with full US phone number" $
+    "(234) 567-8901" @=? prettyPrint "12345678901"
+  , testCase "pretty print amidst text and punctuation" $
+    "(415) 888-0000" @=? prettyPrint "Here it is: 415-888-0000. Thanks!"
   ]


### PR DESCRIPTION
Required because always returning hard-coded 1234567890 should not pass
the tests. See my iteration here:
http://exercism.io/submissions/0d92454ef01942c19ba05e82bd4338db