### PR TITLE
binary-search-tree: Allow empty trees

### DIFF
--- a/exercises/binary-search-tree/binary-search-tree_test.hs
+++ b/exercises/binary-search-tree/binary-search-tree_test.hs
@@ -20,28 +20,28 @@ int4 = 4
 bstTests :: [Test]
 bstTests =
   [ testCase "data is retained" $
-    4 @=? bstValue (singleton int4)
+    Just 4 @=? bstValue (singleton int4)
   , testCase "inserting less" $ do
     let t = insert 2 (singleton int4)
-    4 @=? bstValue t
-    Just 2 @=? bstValue `fmap` bstLeft t
+    Just 4 @=? bstValue t
+    Just 2 @=? (bstLeft t >>= bstValue)
   , testCase "inserting same" $ do
     let t = insert 4 (singleton int4)
-    4 @=? bstValue t
-    Just 4 @=? bstValue `fmap` bstLeft t
+    Just 4 @=? bstValue t
+    Just 4 @=? (bstLeft t >>= bstValue)
   , testCase "inserting right" $ do
     let t = insert 5 (singleton int4)
-    4 @=? bstValue t
-    Just 5 @=? bstValue `fmap` bstRight t
+    Just 4 @=? bstValue t
+    Just 5 @=? (bstRight t >>= bstValue)
   , testCase "complex tree" $ do
     let t = fromList [int4, 2, 6, 1, 3, 7, 5]
-    4 @=? bstValue t
-    Just 2 @=? bstValue `fmap` bstLeft t
-    Just 1 @=? bstValue `fmap` (bstLeft t >>= bstLeft)
-    Just 3 @=? bstValue `fmap` (bstLeft t >>= bstRight)
-    Just 6 @=? bstValue `fmap` bstRight t
-    Just 5 @=? bstValue `fmap` (bstRight t >>= bstLeft)
-    Just 7 @=? bstValue `fmap` (bstRight t >>= bstRight)
+    Just 4 @=? bstValue t
+    Just 2 @=? (bstLeft t >>= bstValue)
+    Just 1 @=? (bstLeft t >>= bstLeft >>= bstValue)
+    Just 3 @=? (bstLeft t >>= bstRight >>= bstValue)
+    Just 6 @=? (bstRight t >>= bstValue)
+    Just 5 @=? (bstRight t >>= bstLeft >>= bstValue)
+    Just 7 @=? (bstRight t >>= bstRight >>= bstValue)
   , testCase "iterating one element" $
     [4] @=? toList (singleton int4)
   , testCase "iterating over smaller element" $

--- a/exercises/binary-search-tree/binary-search-tree_test.hs
+++ b/exercises/binary-search-tree/binary-search-tree_test.hs
@@ -1,6 +1,6 @@
 import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), Counts(..))
 import System.Exit (ExitCode(..), exitWith)
-import BST (bstLeft, bstRight, bstValue, singleton, insert, fromList, toList)
+import BST (bstLeft, bstRight, bstValue, empty, singleton, insert, fromList, toList)
 
 exitProperly :: IO Counts -> IO ()
 exitProperly m = do
@@ -16,6 +16,9 @@ main = exitProperly $ runTestTT $ TestList
 
 int4 :: Int
 int4 = 4
+
+noInts :: [Int]
+noInts = []
 
 bstTests :: [Test]
 bstTests =
@@ -33,6 +36,13 @@ bstTests =
     let t = insert 5 (singleton int4)
     Just 4 @=? bstValue t
     Just 5 @=? (bstRight t >>= bstValue)
+  , testCase "empty list to tree" $
+    empty @=? fromList noInts
+  , testCase "empty list has no value" $
+    Nothing @=? bstValue (fromList noInts)
+  , testCase "inserting into empty" $ do
+    let t = insert int4 empty
+    Just 4 @=? bstValue t
   , testCase "complex tree" $ do
     let t = fromList [int4, 2, 6, 1, 3, 7, 5]
     Just 4 @=? bstValue t
@@ -42,6 +52,8 @@ bstTests =
     Just 6 @=? (bstRight t >>= bstValue)
     Just 5 @=? (bstRight t >>= bstLeft >>= bstValue)
     Just 7 @=? (bstRight t >>= bstRight >>= bstValue)
+  , testCase "empty tree to list" $
+    0 @=? length (toList empty)
   , testCase "iterating one element" $
     [4] @=? toList (singleton int4)
   , testCase "iterating over smaller element" $

--- a/exercises/binary-search-tree/example.hs
+++ b/exercises/binary-search-tree/example.hs
@@ -1,11 +1,27 @@
+{-# LANGUAGE CPP #-}
 module BST ( BST, bstLeft, bstRight, bstValue,
              empty, singleton, insert, fromList, toList
            ) where
-import Data.List (foldl')
+
+#if __GLASGOW_HASKELL__ >= 710
+import Data.Foldable (foldl', toList)
+#else
+-- Foldable, foldMap, mappend, mempty only added to Prelude in 7.10
+import Data.Foldable (Foldable, foldMap, foldl', toList)
+import Data.Monoid (mappend, mempty)
+#endif
 
 data BST a = Tip
            | Node (BST a) a (BST a)
            deriving (Show, Eq)
+
+-- This allows us to use the toList from Foldable.
+-- This may be seen as gratuitous for just one toList function,
+-- but keep in mind now this BST could use other Foldable functions too,
+-- not just toList.
+instance Foldable BST where
+  foldMap _f Tip = mempty
+  foldMap f (Node l v r) = foldMap f l `mappend` f v `mappend` foldMap f r
 
 bstValue :: BST a -> Maybe a
 bstValue Tip = Nothing
@@ -34,7 +50,3 @@ insert x (Node l v r) =
 
 fromList :: Ord a => [a] -> BST a
 fromList = foldl' (flip insert) empty
-
-toList :: BST a -> [a]
-toList Tip = []
-toList (Node l v r) = toList l ++ [v] ++ toList r

--- a/exercises/binary-search-tree/example.hs
+++ b/exercises/binary-search-tree/example.hs
@@ -2,28 +2,38 @@ module BST ( BST, bstLeft, bstRight, bstValue,
              singleton, insert, fromList, toList
            ) where
 import Data.List (foldl')
-import Control.Applicative -- ((<$>), (<|>))
-import Data.Monoid ((<>))
-import Data.Maybe (fromJust)
-import Prelude
 
-data BST a = Node { bstValue :: a
-                  , bstLeft :: Maybe (BST a)
-                  , bstRight :: Maybe (BST a) }
-             deriving (Show, Eq)
+data BST a = Tip
+           | Node (BST a) a (BST a)
+
+bstValue :: BST a -> Maybe a
+bstValue Tip = Nothing
+bstValue (Node _ v _) = Just v
+
+bstLeft :: BST a -> Maybe (BST a)
+bstLeft Tip = Nothing
+bstLeft (Node l _ _) = Just l
+
+bstRight :: BST a -> Maybe (BST a)
+bstRight Tip = Nothing
+bstRight (Node _ _ r) = Just r
+
+empty :: BST a
+empty = Tip
 
 singleton :: Ord a => a -> BST a
-singleton x = Node x Nothing Nothing
+singleton x = Node empty x empty
 
 insert :: Ord a => a -> BST a -> BST a
-insert x n =
-  if bstValue n >= x
-  then n { bstLeft  = insert x <$> bstLeft  n <|> Just (singleton x) }
-  else n { bstRight = insert x <$> bstRight n <|> Just (singleton x) }
+insert x Tip = singleton x
+insert x (Node l v r) =
+  if v >= x
+  then Node (insert x l) v r
+  else Node l v (insert x r)
 
 fromList :: Ord a => [a] -> BST a
-fromList (x:xs) = foldl' (flip insert) (singleton x) xs
-fromList [] = error "tree must not be empty"
+fromList = foldl' (flip insert) empty
 
 toList :: BST a -> [a]
-toList (Node x l r) = fromJust $ (toList <$> l) <> Just [x] <> (toList <$> r)
+toList Tip = []
+toList (Node l v r) = toList l ++ [v] ++ toList r

--- a/exercises/binary-search-tree/example.hs
+++ b/exercises/binary-search-tree/example.hs
@@ -1,10 +1,11 @@
 module BST ( BST, bstLeft, bstRight, bstValue,
-             singleton, insert, fromList, toList
+             empty, singleton, insert, fromList, toList
            ) where
 import Data.List (foldl')
 
 data BST a = Tip
            | Node (BST a) a (BST a)
+           deriving (Show, Eq)
 
 bstValue :: BST a -> Maybe a
 bstValue Tip = Nothing


### PR DESCRIPTION
Since #59 mentioned that it was surprising that binary search trees in this exercise couldn't be empty (since `bstValue` was of type `BST a -> a` rather than `BST a -> Maybe a`) I explored what it would be like if it was allowed.

Unfortunately, now that `data BST` has two variants and is no longer a record, we no longer get "free" implementations of `bstValue`, `bstLeft`, and `bstRight`. However, I found this better than the alternatives:

* `newtype BST a = BST (Maybe (Node a))` means you have to litter `fromBST` and `BST` in various places to convert to/from the `newtype`. I didn't particularly like this, but you can examine this at [my bst-empty-newtype branch](https://github.com/exercism/xhaskell/compare/master...petertseng:bst-empty-newtype?expand=1)
* `type BST a = Maybe (Node a)` works interestingly, but then I can't do the `Foldable` thing done here since the `Foldable` for `Maybe` didn't make sense for the `BST`, but `type` makes them indistinguishable.

As alluded to, since #59 mentions monoids, I made the example tree be an instance of `Foldable` so that the implementation of `toList` comes for free (along with other functions like `sum` and `product`)

See individual commit messages for more detail.