### PR TITLE
Add edge case test for defaults in sum-of-multiples

### DIFF
--- a/exercises/sum-of-multiples/sum-of-multiples_test.hs
+++ b/exercises/sum-of-multiples/sum-of-multiples_test.hs
@@ -35,4 +35,8 @@ sumOfMultiplesTests =
     2203160 @=? sumOfMultiples [43, 47] 10000
   , testCase "[5, 25] 51" $
     275 @=? sumOfMultiples [5,25] 51
+  , testCase "[1] 100" $
+    4950 @=? sumOfMultiples [1] 100
+  , testCase "[] 10000" $
+    0 @=? sumOfMultiples [] 10000
   ]


### PR DESCRIPTION
The README.md says 
> Write a program that can find the sum of the multiples of a given set of numbers. If no set of numbers is given, default to 3 and 5.

I have updated the tests (and example) to add this edge case.