### PR TITLE
added test case for isosceles triangle

### DIFF
--- a/exercises/triangle/triangle_test.hs
+++ b/exercises/triangle/triangle_test.hs
@@ -23,6 +23,7 @@ triangleTests = map TestCase
   , Equilateral @=? tri 10 10 10
   , Isosceles @=? tri 3 4 4
   , Isosceles @=? tri 4 3 4
+  , Isosceles @=? tri 9 12 9
   , Scalene @=? tri 3 4 5
   , Illogical @=? tri 1 1 50
   , Illogical @=? tri 1 2 1


### PR DESCRIPTION
The existing tests missed a case where the two smaller sides were equal. A lot of solutions involved sorting the input, so this matters.