### PR TITLE
Add -fno-warn-type-defaults to supress unwanted warnings.

### DIFF
--- a/exercises/grains/grains_test.hs
+++ b/exercises/grains/grains_test.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -fno-warn-type-defaults #-}
+
 import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), Counts(..))
 import System.Exit (ExitCode(..), exitWith)
 import Grains (square, total)

--- a/exercises/hamming/hamming_test.hs
+++ b/exercises/hamming/hamming_test.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -fno-warn-type-defaults #-}
+
 import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), Counts(..))
 import System.Exit (ExitCode(..), exitWith)
 import Hamming (distance)

--- a/exercises/leap/leap_test.hs
+++ b/exercises/leap/leap_test.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -fno-warn-type-defaults #-}
+
 import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), Counts(..))
 import System.Exit (ExitCode(..), exitWith)
 import LeapYear (isLeapYear)

--- a/exercises/pascals-triangle/pascals-triangle_test.hs
+++ b/exercises/pascals-triangle/pascals-triangle_test.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -fno-warn-type-defaults #-}
+
 import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), Counts(..))
 import System.Exit (ExitCode(..), exitWith)
 import Triangle (row, triangle)

--- a/exercises/scrabble-score/scrabble-score_test.hs
+++ b/exercises/scrabble-score/scrabble-score_test.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -fno-warn-type-defaults #-}
+
 import Test.HUnit ((@=?), runTestTT, Test(..), Counts(..))
 import System.Exit (ExitCode(..), exitWith)
 import Scrabble (scoreLetter, scoreWord)

--- a/exercises/sieve/sieve_test.hs
+++ b/exercises/sieve/sieve_test.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -fno-warn-type-defaults #-}
+
 import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), Counts(..))
 import System.Exit (ExitCode(..), exitWith)
 import Sieve (primesUpTo)

--- a/exercises/sum-of-multiples/sum-of-multiples_test.hs
+++ b/exercises/sum-of-multiples/sum-of-multiples_test.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -fno-warn-type-defaults #-}
+
 import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), Counts(..))
 import System.Exit (ExitCode(..), exitWith)
 import SumOfMultiples (sumOfMultiples)


### PR DESCRIPTION
In some problems, like `leap`, the test module doesn't declare explicitly some numeric types, allowing solutions with multiple types:

```haskell
isLeapYear :: Int     -> Bool
isLeapYear :: Integer -> Bool
```

This is desirable, but has the unintended effect of displaying the warning...

```
Defaulting the following constraint(s) to type `Integer` arising from the use of `isLeapYear` at leap_test.hs ... arising from the literal 1996 ...
```

... when compiling `leap_test.hs` with polymorphic solutions:

```haskell
isLeapYear :: Integral a => a -> Bool
```

It's important to suppress this warning so we don't misguide newcomers in thinking that there is something wrong with their code, when the problem is in the test module. Also, using the most general type is actually encouraged in Haskell.

It's desirable to have test modules that compile silently. This would benefit users and automated tests, that could be compiled with `-Wall -Werror`.

Affected problems:
- grains
- hamming
- leap
- pascals-triangle
- scrabble-score
- sieve
- sum-of-multiples

**Proposed solution**: Add `{-# OPTIONS_GHC -fno-warn-type-defaults #-}` to the affected modules.

Closes #143 