### PR TITLE
Remove unused function testCase generating warning when compiling test modules.

### DIFF
--- a/exercises/atbash-cipher/atbash-cipher_test.hs
+++ b/exercises/atbash-cipher/atbash-cipher_test.hs
@@ -1,4 +1,4 @@
-import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), Counts(..))
+import Test.HUnit ((@=?), runTestTT, Test(..), Counts(..))
 import System.Exit (ExitCode(..), exitWith)
 import Atbash (encode)
 
@@ -6,9 +6,6 @@ exitProperly :: IO Counts -> IO ()
 exitProperly m = do
   counts <- m
   exitWith $ if failures counts /= 0 || errors counts /= 0 then ExitFailure 1 else ExitSuccess
-
-testCase :: String -> Assertion -> Test
-testCase label assertion = TestLabel label (TestCase assertion)
 
 main :: IO ()
 main = exitProperly $ runTestTT $ TestList

--- a/exercises/binary/binary_test.hs
+++ b/exercises/binary/binary_test.hs
@@ -1,4 +1,4 @@
-import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), Counts(..))
+import Test.HUnit ((@=?), runTestTT, Test(..), Counts(..))
 import System.Exit (ExitCode(..), exitWith)
 import Binary (toDecimal)
 
@@ -6,9 +6,6 @@ exitProperly :: IO Counts -> IO ()
 exitProperly m = do
   counts <- m
   exitWith $ if failures counts /= 0 || errors counts /= 0 then ExitFailure 1 else ExitSuccess
-
-testCase :: String -> Assertion -> Test
-testCase label assertion = TestLabel label (TestCase assertion)
 
 main :: IO ()
 main = exitProperly $ runTestTT $ TestList

--- a/exercises/crypto-square/crypto-square_test.hs
+++ b/exercises/crypto-square/crypto-square_test.hs
@@ -1,4 +1,4 @@
-import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), Counts(..))
+import Test.HUnit ((@=?), runTestTT, Test(..), Counts(..))
 import System.Exit (ExitCode(..), exitWith)
 import CryptoSquare (normalizePlaintext,
                      squareSize,
@@ -10,9 +10,6 @@ exitProperly :: IO Counts -> IO ()
 exitProperly m = do
   counts <- m
   exitWith $ if failures counts /= 0 || errors counts /= 0 then ExitFailure 1 else ExitSuccess
-
-testCase :: String -> Assertion -> Test
-testCase label assertion = TestLabel label (TestCase assertion)
 
 main :: IO ()
 main = exitProperly $ runTestTT $ TestList

--- a/exercises/hexadecimal/hexadecimal_test.hs
+++ b/exercises/hexadecimal/hexadecimal_test.hs
@@ -1,4 +1,4 @@
-import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), Counts(..))
+import Test.HUnit ((@=?), runTestTT, Test(..), Counts(..))
 import System.Exit (ExitCode(..), exitWith)
 import Hexadecimal (hexToInt)
 
@@ -6,9 +6,6 @@ exitProperly :: IO Counts -> IO ()
 exitProperly m = do
   counts <- m
   exitWith $ if failures counts /= 0 || errors counts /= 0 then ExitFailure 1 else ExitSuccess
-
-testCase :: String -> Assertion -> Test
-testCase label assertion = TestLabel label (TestCase assertion)
 
 main :: IO ()
 main = exitProperly $ runTestTT $ TestList

--- a/exercises/largest-series-product/largest-series-product_test.hs
+++ b/exercises/largest-series-product/largest-series-product_test.hs
@@ -1,4 +1,4 @@
-import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), Counts(..))
+import Test.HUnit ((@=?), runTestTT, Test(..), Counts(..))
 import System.Exit (ExitCode(..), exitWith)
 import Series (largestProduct)
 
@@ -6,9 +6,6 @@ exitProperly :: IO Counts -> IO ()
 exitProperly m = do
   counts <- m
   exitWith $ if failures counts /= 0 || errors counts /= 0 then ExitFailure 1 else ExitSuccess
-
-testCase :: String -> Assertion -> Test
-testCase label assertion = TestLabel label (TestCase assertion)
 
 main :: IO ()
 main = exitProperly $ runTestTT $ TestList

--- a/exercises/nth-prime/nth-prime_test.hs
+++ b/exercises/nth-prime/nth-prime_test.hs
@@ -1,4 +1,4 @@
-import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), Counts(..))
+import Test.HUnit ((@=?), runTestTT, Test(..), Counts(..))
 import System.Exit (ExitCode(..), exitWith)
 import Prime (nth)
 
@@ -6,9 +6,6 @@ exitProperly :: IO Counts -> IO ()
 exitProperly m = do
   counts <- m
   exitWith $ if failures counts /= 0 || errors counts /= 0 then ExitFailure 1 else ExitSuccess
-
-testCase :: String -> Assertion -> Test
-testCase label assertion = TestLabel label (TestCase assertion)
 
 main :: IO ()
 main = exitProperly $ runTestTT $ TestList

--- a/exercises/prime-factors/prime-factors_test.hs
+++ b/exercises/prime-factors/prime-factors_test.hs
@@ -1,4 +1,4 @@
-import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), Counts(..))
+import Test.HUnit ((@=?), runTestTT, Test(..), Counts(..))
 import System.Exit (ExitCode(..), exitWith)
 import PrimeFactors (primeFactors)
 
@@ -6,9 +6,6 @@ exitProperly :: IO Counts -> IO ()
 exitProperly m = do
   counts <- m
   exitWith $ if failures counts /= 0 || errors counts /= 0 then ExitFailure 1 else ExitSuccess
-
-testCase :: String -> Assertion -> Test
-testCase label assertion = TestLabel label (TestCase assertion)
 
 main :: IO ()
 main = exitProperly $ runTestTT $ TestList

--- a/exercises/raindrops/raindrops_test.hs
+++ b/exercises/raindrops/raindrops_test.hs
@@ -1,4 +1,4 @@
-import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), Counts(..))
+import Test.HUnit ((@=?), runTestTT, Test(..), Counts(..))
 import System.Exit (ExitCode(..), exitWith)
 import Raindrops (convert)
 
@@ -6,9 +6,6 @@ exitProperly :: IO Counts -> IO ()
 exitProperly m = do
   counts <- m
   exitWith $ if failures counts /= 0 || errors counts /= 0 then ExitFailure 1 else ExitSuccess
-
-testCase :: String -> Assertion -> Test
-testCase label assertion = TestLabel label (TestCase assertion)
 
 main :: IO ()
 main = exitProperly $ runTestTT $ TestList

--- a/exercises/roman-numerals/roman-numerals_test.hs
+++ b/exercises/roman-numerals/roman-numerals_test.hs
@@ -1,4 +1,4 @@
-import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), Counts(..))
+import Test.HUnit ((@=?), runTestTT, Test(..), Counts(..))
 import System.Exit (ExitCode(..), exitWith)
 import Roman (numerals)
 
@@ -6,9 +6,6 @@ exitProperly :: IO Counts -> IO ()
 exitProperly m = do
   counts <- m
   exitWith $ if failures counts /= 0 || errors counts /= 0 then ExitFailure 1 else ExitSuccess
-
-testCase :: String -> Assertion -> Test
-testCase label assertion = TestLabel label (TestCase assertion)
 
 main :: IO ()
 main = exitProperly $ runTestTT $ TestList

--- a/exercises/scrabble-score/scrabble-score_test.hs
+++ b/exercises/scrabble-score/scrabble-score_test.hs
@@ -1,4 +1,4 @@
-import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), Counts(..))
+import Test.HUnit ((@=?), runTestTT, Test(..), Counts(..))
 import System.Exit (ExitCode(..), exitWith)
 import Scrabble (scoreLetter, scoreWord)
 
@@ -6,9 +6,6 @@ exitProperly :: IO Counts -> IO ()
 exitProperly m = do
   counts <- m
   exitWith $ if failures counts /= 0 || errors counts /= 0 then ExitFailure 1 else ExitSuccess
-
-testCase :: String -> Assertion -> Test
-testCase label assertion = TestLabel label (TestCase assertion)
 
 main :: IO ()
 main = exitProperly $ runTestTT $ TestList

--- a/exercises/triangle/triangle_test.hs
+++ b/exercises/triangle/triangle_test.hs
@@ -1,4 +1,4 @@
-import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), Counts(..))
+import Test.HUnit ((@=?), runTestTT, Test(..), Counts(..))
 import System.Exit (ExitCode(..), exitWith)
 import Triangle (TriangleType(..), triangleType)
 
@@ -6,9 +6,6 @@ exitProperly :: IO Counts -> IO ()
 exitProperly m = do
   counts <- m
   exitWith $ if failures counts /= 0 || errors counts /= 0 then ExitFailure 1 else ExitSuccess
-
-testCase :: String -> Assertion -> Test
-testCase label assertion = TestLabel label (TestCase assertion)
 
 main :: IO ()
 main = exitProperly $ runTestTT $ TestList


### PR DESCRIPTION
Some exercises show a warning when compiling the test module:

```
Defined but not used: `testCase`
```

This can confuse users and is not considered good practice.

Unused code:

- function `testCase`
- import of `Assertion`

Affected exercises:

- atbash-cipher
- binary
- crypto-square
- hexadecimal
- largest-series-product
- nth-prime
- prime-factors
- raindrops
- roman-numerals
- scrabble-score
- triangle

Closes #145 