### PR TITLE
check-exercises: Fix warning with ghc >= 7.10.

### DIFF
--- a/_test/check-exercises.hs
+++ b/_test/check-exercises.hs
@@ -15,7 +15,10 @@ import System.Process (rawSystem)
 import Data.List (isPrefixOf, intercalate)
 import Data.Maybe (catMaybes)
 import Control.Monad (filterM)
-import Control.Applicative
+
+-- base >= 4.8 re-exports Control.Applicative.<$>.
+import Control.Applicative -- This is only need for <$>,  if GHC <  7.10
+import Prelude             -- This trick avoids a warning if GHC >= 7.10
 
 withTemporaryDirectory_ :: FilePath -> IO a -> IO a
 withTemporaryDirectory_ fp f =


### PR DESCRIPTION
This fixes the warning *"The import of Control.Applicative is redundant"* when compiling `check-exercises` caused by `Prelude` re-exporting `Control.Applicative.<$>` in `base >= 4.8`.

Removing the offending line is undesirable because it would break compiling if `ghc <= 7.10`.

Closes #122 