### PR TITLE
New .gitignore based on GitHub's default.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,29 @@
-*.swp
-.DS_Store
-tmp
+# exercism specific patterns
 bin/configlet
 bin/configlet.exe
-/.vagrant
+
+# exercism/xhaskell specific patterns
+*.cabal
+package.yaml
+stack.yaml
+
+# sorted default .gitignore from github/gitignore/Haskell.gitignore
+*.aux
+*.chi
+*.chs.h
+*.dyn_hi
+*.dyn_o
+*.eventlog
+*.hi
+*.hp
+*.o
+*.prof
+.cabal-sandbox/
+.hpc
+.hsenv
+.stack-work/
+cabal-dev
+cabal.project.local
+cabal.sandbox.config
+dist
+dist-*


### PR DESCRIPTION
Add new entries to .gitignore to make move convenient for
contributors to use alternative build methods.

 - Default .ignore exclusions for Haskell from GitHub.
 - Exclusions for development with cabal-sandboxes, stack and hpack.
 - Reordering.