### PR TITLE
Changing return types for phone-number exercise to be Maybes

### DIFF
--- a/exercises/phone-number/example.hs
+++ b/exercises/phone-number/example.hs
@@ -1,24 +1,28 @@
 module Phone (number, areaCode, prettyPrint) where
 import Data.Char (isDigit)
 
-number :: String -> String
+number :: String -> Maybe String
 number input
-  | len == 10 = digits
-  | len == 11 && head digits == '1' = tail digits
-  | otherwise = replicate 10 '0'
+  | len == 10 = Just digits
+  | len == 11 && head digits == '1' = Just $ tail digits
+  | otherwise = Nothing
   where digits = filter isDigit input
         len = length digits
 
-parts :: String -> (String, String, String)
-parts input = (ac, exchange, subscriber)
-  where
-    (ac, exchangeSubscriber) = splitAt 3 (number input)
-    (exchange, subscriber) = splitAt 3 exchangeSubscriber
+parts :: String -> Maybe (String, String, String)
+parts input = case number input of
+    Nothing   -> Nothing
+    Just digits -> Just (ac, exchange, subscriber)
+      where
+        (ac, exchangeSubscriber) = splitAt 3 digits
+        (exchange, subscriber) = splitAt 3 exchangeSubscriber
 
-areaCode :: String -> String
-areaCode input = ac
-  where (ac, _, _) = parts input
+areaCode :: String -> Maybe String
+areaCode input = case parts input of
+  Just (ac, _, _) -> Just ac
+  Nothing         -> Nothing
 
-prettyPrint :: String -> String
-prettyPrint input = "(" ++ ac ++ ") " ++ exchange ++ "-" ++ subscriber
-  where (ac, exchange, subscriber) = parts input
+prettyPrint :: String -> Maybe String
+prettyPrint input = case parts input of
+  Just (ac, exchange, subscriber) -> Just $ "(" ++ ac ++ ") " ++ exchange ++ "-" ++ subscriber
+  Nothing                         -> Nothing

--- a/exercises/phone-number/phone-number_test.hs
+++ b/exercises/phone-number/phone-number_test.hs
@@ -19,51 +19,51 @@ main = exitProperly $ runTestTT $ TestList
 numberTests :: [Test]
 numberTests =
   [ testCase "cleans number" $
-    "1234567890" @=? number "(123) 456-7890"
+    Just "1234567890" @=? number "(123) 456-7890"
   , testCase "cleans another number" $
-    "6125551212" @=? number "(612) 555-1212"
+    Just "6125551212" @=? number "(612) 555-1212"
   , testCase "cleans number with dots" $
-    "1234567890" @=? number "123.456.7890"
+    Just "1234567890" @=? number "123.456.7890"
   , testCase "cleans another number with dots" $
-    "9187654321" @=? number "918.765.4321"
+    Just "9187654321" @=? number "918.765.4321"
   , testCase "valid when 11 digits and first is 1" $
-    "2468013579" @=? number "12468013579"
+    Just "2468013579" @=? number "12468013579"
   , testCase "invalid when 11 digits" $
-    "0000000000" @=? number "21234567890"
+    Nothing @=? number "21234567890"
   , testCase "invalid when 9 digits" $
-    "0000000000" @=? number "123456789"
+    Nothing @=? number "123456789"
   , testCase "invalid when 12 digits" $
-    "0000000000" @=? number "123456789012"
+    Nothing @=? number "123456789012"
   , testCase "invalid when empty" $
-    "0000000000" @=? number ""
+    Nothing @=? number ""
   , testCase "invalid when no digits present" $
-    "0000000000" @=? number " (-) "
+    Nothing @=? number " (-) "
   , testCase "valid with leading characters" $
-    "2358132134" @=? number "my number is 235 813 2134"
+    Just "2358132134" @=? number "my number is 235 813 2134"
   , testCase "valid with trailing characters" $
-    "9876543210" @=? number "987 654 3210 - bob"
+    Just "9876543210" @=? number "987 654 3210 - bob"
   , testCase "valid amidst text and punctuation" $
-    "4158880000" @=? number "Here it is: 415-888-0000. Thanks!"
+    Just "4158880000" @=? number "Here it is: 415-888-0000. Thanks!"
   ]
 
 areaCodeTests :: [Test]
 areaCodeTests =
   [ testCase "area code" $
-    "123" @=? areaCode "1234567890"
+    Just "123" @=? areaCode "1234567890"
   , testCase "area code with parentheses" $
-    "612" @=? areaCode "(612) 555-1212"
+    Just "612" @=? areaCode "(612) 555-1212"
   , testCase "area code with leading characters" $
-    "235" @=? areaCode "my number is 235 813 2134"
+    Just "235" @=? areaCode "my number is 235 813 2134"
   , testCase "invalid area code" $
-    "000" @=? areaCode " (-) "
+    Nothing @=? areaCode " (-) "
   ]
 
 prettyPrintTests :: [Test]
 prettyPrintTests =
   [ testCase "pretty print" $
-    "(123) 456-7890" @=? prettyPrint "1234567890"
+    Just "(123) 456-7890" @=? prettyPrint "1234567890"
   , testCase "pretty print with full US phone number" $
-    "(234) 567-8901" @=? prettyPrint "12345678901"
+    Just "(234) 567-8901" @=? prettyPrint "12345678901"
   , testCase "pretty print amidst text and punctuation" $
-    "(415) 888-0000" @=? prettyPrint "Here it is: 415-888-0000. Thanks!"
+    Just "(415) 888-0000" @=? prettyPrint "Here it is: 415-888-0000. Thanks!"
   ]


### PR DESCRIPTION
Signaling invalid input to phone number parsing by returning a Nothing
instead of a string of 0's. This better represents idiomatic haskell,
and also signifies a difference between an input of all 0's and an
invalid input.

Closes #158