### PR TITLE
rna-transcription: Changes return type to Maybe

### DIFF
--- a/exercises/rna-transcription/DNA.hs
+++ b/exercises/rna-transcription/DNA.hs
@@ -1,0 +1,6 @@
+module DNA (toRNA) where
+
+-- | if string contains invalid character, return Nothing
+-- | if string contains only valid nucleotides, return Just transcription
+toRNA :: String -> Maybe String
+toRNA = undefined

--- a/exercises/rna-transcription/example.hs
+++ b/exercises/rna-transcription/example.hs
@@ -1,9 +1,12 @@
 module DNA (toRNA) where
 
-toRNA :: String -> String
-toRNA = map $ \c -> case c of
-  'C' -> 'G'
-  'G' -> 'C'
-  'A' -> 'U'
-  'T' -> 'A'
-  _ -> error $ "Invalid DNA-base: " ++ show c
+import qualified Data.Map.Strict as Map
+
+toRNA :: String -> Maybe String
+toRNA = mapM (`Map.lookup` rna)
+  where
+    rna = Map.fromList [ ('C', 'G')
+                       , ('G', 'C')
+                       , ('A', 'U')
+                       , ('T', 'A') ]
+

--- a/exercises/rna-transcription/rna-transcription_test.hs
+++ b/exercises/rna-transcription/rna-transcription_test.hs
@@ -13,15 +13,21 @@ testCase label assertion = TestLabel label (TestCase assertion)
 toRNATests :: [Test]
 toRNATests =
   [ testCase "transcribes cytosine to guanine" $
-    "G" @=? toRNA "C"
+    Just "G" @=? toRNA "C"
   , testCase "transcribes guanine to cytosine" $
-    "C" @=? toRNA "G"
+    Just "C" @=? toRNA "G"
   , testCase "transcribes adenine to uracil" $
-    "U" @=? toRNA "A"
+    Just "U" @=? toRNA "A"
   , testCase "transcribes thymine to adenine" $
-    "A" @=? toRNA "T"
+    Just "A" @=? toRNA "T"
   , testCase "transcribes all ACGT to UGCA" $
-    "UGCACCAGAAUU" @=? toRNA "ACGTGGTCTTAA"
+    Just "UGCACCAGAAUU" @=? toRNA "ACGTGGTCTTAA"
+  , testCase "transcribes RNA only nucleotide uracil to Nothing" $
+    Nothing @=? toRNA "U"
+  , testCase "transcribes completely invalid DNA to Nothing" $
+    Nothing @=? toRNA "XXX"
+  , testCase "transcribes partially invalid DNA to Nothing" $
+    Nothing @=? toRNA "ACGTXXXCTTAA"
   ]
 
 main :: IO ()


### PR DESCRIPTION
- Error case is now defined, eliminating the desire to throw an `error`
for invalid input.
- The test and example solution are more idiomatic to Haskell, using a
  `Maybe`.

Closes #166