### PR TITLE
README: Explain significance of adding _test to path

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ This will transform the exercise *leap* in a *stack project* using the
 resolver *lts-6.4*. Change it for your favourite [Stackage snapshot](https://www.stackage.org/snapshots).
 
 *You can make you life easier adding _test to your path.*
+That way you can simply call `stackalize` from anywhere instead of having
+to provide a full path to `_test/stackalize`.
 
 ##### Testing with default settings
 


### PR DESCRIPTION
Whether this is necessary depends on whom we are targeting with this
README. If we think everyone reading it already knows what it means to
add to the PATH, then we don't need this.

This commit, if we merge it, does not make that assumption, so we
explain why someone might want to add _test to path.

It's noted that the README doesn't provide instructions on how to add
something to the PATH but this would be a tricky endeavor as the way to
do so may differ, so we'd have to discuss it.