### PR TITLE
all-your-base: Add new exercise

### DIFF
--- a/_test/dependencies.txt
+++ b/_test/dependencies.txt
@@ -1,5 +1,7 @@
 accumulate/example.hs: base
 accumulate/accumulate_test.hs: base HUnit
+all-your-base/example.hs: base
+all-your-base/all-your-base_test.hs: base HUnit
 allergies/example.hs: base
 allergies/allergies_test.hs: base HUnit
 anagram/example.hs: base

--- a/config.json
+++ b/config.json
@@ -34,6 +34,7 @@
     "raindrops",
     "allergies",
     "atbash-cipher",
+    "all-your-base",
     "bank-account",
     "crypto-square",
     "kindergarten-garden",

--- a/exercises/all-your-base/Base.hs
+++ b/exercises/all-your-base/Base.hs
@@ -1,0 +1,4 @@
+module Base (rebase) where
+
+rebase :: Integral a => a -> a -> [a] -> Maybe [a]
+rebase inputBase outputBase inputDigits = undefined

--- a/exercises/all-your-base/all-your-base_test.hs
+++ b/exercises/all-your-base/all-your-base_test.hs
@@ -1,0 +1,165 @@
+{-# LANGUAGE RecordWildCards #-}
+
+import Control.Monad (unless)
+import System.Exit   (exitFailure)
+
+import Test.HUnit
+    ( (~:)
+    , (~=?)
+    , Counts (failures, errors)
+    , Test   (TestList)
+    , runTestTT
+    )
+
+import Base (rebase)
+
+main :: IO ()
+main = do
+         counts <- runTestTT tests
+         unless (failures counts == 0 && errors counts == 0) exitFailure
+
+tests :: Test
+tests = TestList $ map test cases
+  where
+    test (Case {..}) =   description
+                     ~:  rebase inputBase outputBase inputDigits
+                     ~=? outputDigits
+
+data Case = Case { description  ::        String
+                 , inputBase    ::        Integer
+                 , inputDigits  ::       [Integer]
+                 , outputBase   ::        Integer
+                 , outputDigits :: Maybe [Integer]
+                 }
+
+-- Test cases adapted from x-common/all-your-base.json from 2016-06-29.
+cases :: [Case]
+cases = [ Case { description  = "single bit one to decimal"
+               , inputBase    = 2
+               , inputDigits  = [1]
+               , outputBase   = 10
+               , outputDigits = Just [1]
+               },
+          Case { description  = "binary to single decimal"
+               , inputBase    = 2
+               , inputDigits  = [1, 0, 1]
+               , outputBase   = 10
+               , outputDigits = Just [5]
+               },
+          Case { description  = "single decimal to binary"
+               , inputBase    = 10
+               , inputDigits  = [5]
+               , outputBase   = 2
+               , outputDigits = Just [1, 0, 1]
+               },
+          Case { description  = "binary to multiple decimal"
+               , inputBase    = 2
+               , inputDigits  = [1, 0, 1, 0, 1, 0]
+               , outputBase   = 10
+               , outputDigits = Just [4, 2]
+               },
+          Case { description  = "decimal to binary"
+               , inputBase    = 10
+               , inputDigits  = [4, 2]
+               , outputBase   = 2
+               , outputDigits = Just [1, 0, 1, 0, 1, 0]
+               },
+          Case { description  = "trinary to hexadecimal"
+               , inputBase    = 3
+               , inputDigits  = [1, 1, 2, 0]
+               , outputBase   = 16
+               , outputDigits = Just [2, 10]
+               },
+          Case { description  = "hexadecimal to trinary"
+               , inputBase    = 16
+               , inputDigits  = [2, 10]
+               , outputBase   = 3
+               , outputDigits = Just [1, 1, 2, 0]
+               },
+          Case { description  = "15-bit integer"
+               , inputBase    = 97
+               , inputDigits  = [3, 46, 60]
+               , outputBase   = 73
+               , outputDigits = Just [6, 10, 45]
+               },
+          -- The following cases are undefined in all-your-base.json.
+          -- Here we use [] to represent the lack of digits, i.e., zero.
+          Case { description  = "empty list"
+               , inputBase    = 2
+               , inputDigits  = []
+               , outputBase   = 10
+               , outputDigits = Just []
+               },
+          Case { description  = "single zero"
+               , inputBase    = 10
+               , inputDigits  = [0]
+               , outputBase   = 2
+               , outputDigits = Just []
+               },
+          Case { description  = "multiple zeros"
+               , inputBase    = 10
+               , inputDigits  = [0, 0, 0]
+               , outputBase   = 2
+               , outputDigits = Just []
+               },
+          Case { description  = "leading zeros"
+               , inputBase    = 7
+               , inputDigits  = [0, 6, 0]
+               , outputBase   = 10
+               , outputDigits = Just [4, 2]
+               },
+          Case { description  = "negative digit"
+               , inputBase    = 2
+               , inputDigits  = [1, (-1), 1, 0, 1, 0]
+               , outputBase   = 10
+               , outputDigits = Nothing
+               },
+          Case { description  = "invalid positive digit"
+               , inputBase    = 2
+               , inputDigits  = [1, 2, 1, 0, 1, 0]
+               , outputBase   = 10
+               , outputDigits = Nothing
+               },
+          Case { description  = "first base is one"
+               , inputBase    = 1
+               , inputDigits  = []
+               , outputBase   = 10
+               , outputDigits = Nothing
+               },
+          Case { description  = "second base is one"
+               , inputBase    = 2
+               , inputDigits  = [1, 0, 1, 0, 1, 0]
+               , outputBase   = 1
+               , outputDigits = Nothing
+               },
+          Case { description  = "first base is zero"
+               , inputBase    = 0
+               , inputDigits  = []
+               , outputBase   = 10
+               , outputDigits = Nothing
+               },
+          Case { description  = "second base is zero"
+               , inputBase    = 10
+               , inputDigits  = [7]
+               , outputBase   = 0
+               , outputDigits = Nothing
+               },
+          Case { description  = "first base is negative"
+               , inputBase    = (-2)
+               , inputDigits  = [1]
+               , outputBase   = 10
+               , outputDigits = Nothing
+               },
+          Case { description  = "second base is negative"
+               , inputBase    = 2
+               , inputDigits  = [1]
+               , outputBase   = (-7)
+               , outputDigits = Nothing
+               },
+          Case { description  = "both bases are negative"
+               , inputBase    = (-2)
+               , inputDigits  = [1]
+               , outputBase   = (-7)
+               , outputDigits = Nothing
+               }
+        ]

--- a/exercises/all-your-base/example.hs
+++ b/exercises/all-your-base/example.hs
@@ -1,0 +1,26 @@
+module Base (rebase) where
+
+-- base >= 4.8 re-exports Control.Applicative.(<$>)
+import Control.Applicative -- This is only need for <$>,  if GHC <  7.10
+import Prelude             -- This trick avoids a warning if GHC >= 7.10
+
+import Control.Monad (foldM)
+import Data.List     (unfoldr)
+import Data.Tuple    (swap)
+
+rebase :: Integral a => a -> a -> [a] -> Maybe [a]
+rebase ibase obase ds
+    | ibase < 2 = Nothing
+    | obase < 2 = Nothing
+    | otherwise = toDigits obase <$> fromDigits ibase ds
+  where
+
+    fromDigits base = foldM f 0
+      where
+        f acc x | x >= 0 && x < base = Just (acc * base + x)
+                | otherwise          = Nothing
+
+    toDigits base n = reverse . unfoldr f $ n
+      where
+        f 0 = Nothing
+        f x = Just . swap $ x `divMod` base


### PR DESCRIPTION
Add the tests, an example solution and a stub.
Add exercise to `config.json`, after `atbash-cipher`.
Add dependencies to `dependencies.txt`.

Closes #167 