### PR TITLE
etl: Change letter representation to Char

### DIFF
--- a/exercises/etl/ETL.hs
+++ b/exercises/etl/ETL.hs
@@ -1,0 +1,6 @@
+module ETL (transform) where
+
+import Data.Map (Map)
+
+transform :: Map a String -> Map Char a
+transform = undefined

--- a/exercises/etl/etl_test.hs
+++ b/exercises/etl/etl_test.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -fno-warn-type-defaults #-}
+
 import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), Counts(..))
 import System.Exit (ExitCode(..), exitWith)
 import ETL (transform)
@@ -18,32 +20,32 @@ main = exitProperly $ runTestTT $ TestList
 transformTests :: [Test]
 transformTests =
   [ testCase "transform one value" $
-    M.fromList [("a", 1)] @=? transform (M.fromList [(1, ["A"])])
+    M.fromList [('a', 1)] @=? transform (M.fromList [(1, "A")])
   , testCase "transform multiple keys from one value" $
-    M.fromList [("a", 1), ("e", 1)] @=? transform (M.fromList [(1, ["A", "E"])])
+    M.fromList [('a', 1), ('e', 1)] @=? transform (M.fromList [(1, "AE")])
   , testCase "transform multiple keys from multiple values" $
-    M.fromList [("a", 1), ("b", 4)] @=?
-    transform (M.fromList [(1, ["A"]), (4, ["B"])])
+    M.fromList [('a', 1), ('b', 4)] @=?
+    transform (M.fromList [(1, "A"), (4, "B")])
   , testCase "full dataset" $
     M.fromList fullOut @=? transform (M.fromList fullIn)
   ]
 
-fullOut :: [(String, Int)]
+fullOut :: [(Char, Int)]
 fullOut =
-  [ ("a", 1), ("b", 3), ("c", 3), ("d", 2), ("e", 1)
-  , ("f", 4), ("g", 2), ("h", 4), ("i", 1), ("j", 8)
-  , ("k", 5), ("l", 1), ("m", 3), ("n", 1), ("o", 1)
-  , ("p", 3), ("q", 10), ("r", 1), ("s", 1), ("t", 1)
-  , ("u", 1), ("v", 4), ("w", 4), ("x", 8), ("y", 4)
-  , ("z", 10) ]
+  [ ('a', 1), ('b', 3), ('c', 3), ('d', 2), ('e', 1)
+  , ('f', 4), ('g', 2), ('h', 4), ('i', 1), ('j', 8)
+  , ('k', 5), ('l', 1), ('m', 3), ('n', 1), ('o', 1)
+  , ('p', 3), ('q', 10), ('r', 1), ('s', 1), ('t', 1)
+  , ('u', 1), ('v', 4), ('w', 4), ('x', 8), ('y', 4)
+  , ('z', 10) ]
 
-fullIn :: [(Int, [String])]
+fullIn :: [(Int, String)]
 fullIn =
-  [ (1, map (:[]) "AEIOULNRST")
-  , (2, ["D", "G"])
-  , (3, map (:[]) "BCMP")
-  , (4, map (:[]) "FHVWY")
-  , (5, ["K"])
-  , (8, ["J", "X"])
-  , (10, ["Q", "Z"])
+  [ (1, "AEIOULNRST")
+  , (2, "DG")
+  , (3, "BCMP")
+  , (4, "FHVWY")
+  , (5, "K")
+  , (8, "JX")
+  , (10,"QZ")
   ]

--- a/exercises/etl/example.hs
+++ b/exercises/etl/example.hs
@@ -3,9 +3,9 @@ import Data.Char (toLower)
 import qualified Data.Map as M
 
 type PointValue = Int
-type LowerTile = String
-type UpperTile = String
+type LowerTile = Char
+type UpperTile = Char
 
 transform :: M.Map PointValue [UpperTile] -> M.Map LowerTile PointValue
 transform = M.fromList . concatMap go . M.toList
-  where go (v, tiles) = zip (map (map toLower) tiles) (repeat v)
+  where go (v, tiles) = zip (map toLower tiles) (repeat v)


### PR DESCRIPTION
The `etl` exercise uses `String` to represent each letter in both, the input and the output of `transform`.
This is unidiomatic because, in Haskell, a single haracter is not the same type as a list of characters.

To avoid exposing users to unidiomatic code and ease understanding of what is being asked in this exercise, I propose the following changes:

1. Change letter representation from String to Char.
2. Add stub solution.