### PR TITLE
queen-attack: Explain positions and white/black

### DIFF
--- a/exercises/queen-attack/src/Queens.hs
+++ b/exercises/queen-attack/src/Queens.hs
@@ -1,7 +1,12 @@
 module Queens (boardString, canAttack) where
 
+-- Positions are specified as two-tuples.
+-- The first element is is the column (file in Chess terms).
+-- The second element is the row (rank in Chess terms).
+-- (0, 0) is the top left of the board, and (7, 7) is the bottom right.
+
 boardString :: Maybe (Int, Int) -> Maybe (Int, Int) -> String
-boardString = undefined
+boardString white black = undefined
 
 canAttack :: (Int, Int) -> (Int, Int) -> Bool
 canAttack = undefined


### PR DESCRIPTION
Taking the suggestions of https://github.com/exercism/xhaskell/pull/200/files#r71086758
into account, it seemed prudent to explain enough so that it is clear
from just looking at the stub file what is expected. This seems to be in
line with the goals of #181 which explains that we wish to save users
from inspecting the test suites to figure out what they need to
implement.