### PR TITLE
accumulate: fix inefficient example

### DIFF
--- a/exercises/accumulate/src/Example.hs
+++ b/exercises/accumulate/src/Example.hs
@@ -14,9 +14,9 @@ accumulate f xs = [f x | x <- xs]
 
 -- Commonly submitted inefficient solution (we test for this now):
 
-accumulate f xs = accumulate' []
+accumulate f = accumulate' []
   where
-    accumulate' acc []     = acc
+    accumulate' acc []     = reverse acc
     accumulate' acc (x:xs) = accumulate' (f x : acc) xs
 
 -}


### PR DESCRIPTION
The intent, I believe, is to show an example that would work and gives
correct results but fails the non-strictness test. It was added in
d238a331c2bccaa1d86522198e0a85235a6356d6.

In order for it to compile, the `xs` needs to be removed (an eta
reduction has happened).

In order for the results to be correct, final `acc` must be reversed.