### PR TITLE
strain: Add test for non-strict keep and discard

### DIFF
--- a/exercises/strain/test/Tests.hs
+++ b/exercises/strain/test/Tests.hs
@@ -46,4 +46,10 @@ strainTests =
   , testCase "discard strings" $ do
     let ws = ["apple", "zebra", "banana", "zombies", "cherimoya", "zealot"]
     ["apple", "banana", "cherimoya"] @=? discard (isPrefixOf "z") ws
+  , testCase "keep non-strict" $ do
+    let ws = "yes" : error "keep should be lazier - don't look at list elements you don't need!"
+    ["yes"] @=? take 1 (keep (const True) ws)
+  , testCase "discard non-strict" $ do
+    let ws = "yes" : error "discard should be lazier - don't look at list elements you don't need!"
+    ["yes"] @=? take 1 (discard (const False) ws)
   ]


### PR DESCRIPTION
Just as d238a331c2bccaa1d86522198e0a85235a6356d6 added a test for
accumulate to be non-strict, we add a test for keep and discard that
does the same.

For the purpose of #194
Closes #208