### PR TITLE
sublist: Rewrite tests to use hspec with fail-fast.

### DIFF
--- a/exercises/sublist/package.yaml
+++ b/exercises/sublist/package.yaml
@@ -16,4 +16,4 @@ tests:
     source-dirs: test
     dependencies:
       - sublist
-      - HUnit
+      - hspec


### PR DESCRIPTION
- Rewrite to use hspec.
- Add tests to match the json file.
- Remove most of the tests not matching the json file.

Related to #211.
