### PR TITLE
grains: Rewrite tests to use hspec with fail-fast.

### DIFF
--- a/exercises/grains/package.yaml
+++ b/exercises/grains/package.yaml
@@ -16,4 +16,4 @@ tests:
     source-dirs: test
     dependencies:
       - grains
-      - HUnit
+      - hspec

--- a/exercises/grains/test/Tests.hs
+++ b/exercises/grains/test/Tests.hs
@@ -1,49 +1,44 @@
 {-# OPTIONS_GHC -fno-warn-type-defaults #-}
 
-import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), Counts(..))
-import System.Exit (ExitCode(..), exitWith)
+import Data.Foldable     (for_)
+import Test.Hspec        (Spec, describe, it, shouldBe)
+import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+
 import Grains (square, total)
 
-exitProperly :: IO Counts -> IO ()
-exitProperly m = do
-  counts <- m
-  exitWith $ if failures counts /= 0 || errors counts /= 0 then ExitFailure 1 else ExitSuccess
-
-testCase :: String -> Assertion -> Test
-testCase label assertion = TestLabel label (TestCase assertion)
-
 main :: IO ()
-main = exitProperly $ runTestTT $ TestList
-       [ TestList grainsTests ]
+main = hspecWith defaultConfig {configFastFail = True} specs
 
-i :: Integral a => a -> Integer
-i = fromIntegral
+specs :: Spec
+specs = describe "grains" $ do
+          describe "square" $ for_ squareCases squareTest
+          describe "total"  $ totalTest totalCase
+  where
 
-mi :: Integral a => Maybe a -> Maybe Integer
-mi = fmap fromIntegral
+    squareTest (description, n, expected) = it description assertion
+      where
+        assertion  = expression `shouldBe` expected
+        expression = fmap fromIntegral . square . fromIntegral $ n
 
-grainsTests :: [Test]
-grainsTests =
-  [ testCase "square 1" $
-    Just 1 @=? mi (square 1)
-  , testCase "square 2" $
-    Just 2 @=? mi (square 2)
-  , testCase "square 3" $
-    Just 4 @=? mi (square 3)
-  , testCase "square 4" $
-    Just 8 @=? mi (square 4)
-  , testCase "square 16" $
-    Just 32768 @=? mi (square 16)
-  , testCase "square 32" $
-    Just 2147483648 @=? mi (square 32)
-  , testCase "square 64" $
-    Just 9223372036854775808 @=? mi (square 64)
-  , testCase "square negative" $
-    Nothing @=? mi (square (-1))
-  , testCase "square 0" $
-    Nothing @=? mi (square 0)
-  , testCase "square bigger than 64" $
-    Nothing @=? mi (square 65)
-  , testCase "total grains" $
-    18446744073709551615 @=? i total
-  ]
+    totalTest (description, expected) = it description assertion
+      where
+        assertion = fromIntegral total `shouldBe` expected
+
+-- As of 2016-07-27, there was no reference file
+-- for the test cases in `exercism/x-common`.
+
+squareCases :: [(String, Integer, Maybe Integer)]
+squareCases =
+    [ ("square 1"             ,  1, Just                   1)
+    , ("square 2"             ,  2, Just                   2)
+    , ("square 3"             ,  3, Just                   4)
+    , ("square 4"             ,  4, Just                   8)
+    , ("square 16"            , 16, Just               32768)
+    , ("square 32"            , 32, Just          2147483648)
+    , ("square 64"            , 64, Just 9223372036854775808)
+    , ("square negative"      , -1, Nothing                 )
+    , ("square 0"             ,  0, Nothing                 )
+    , ("square bigger than 64", 65, Nothing                 ) ]
+
+totalCase :: (String, Integer)
+totalCase = ("total grains", 18446744073709551615)


### PR DESCRIPTION
Related to #211.
