### PR TITLE
bob: Rewrite tests to use hspec with fail-fast.

### DIFF
--- a/exercises/bob/package.yaml
+++ b/exercises/bob/package.yaml
@@ -16,4 +16,4 @@ tests:
     source-dirs: test
     dependencies:
       - bob
-      - HUnit
+      - hspec

--- a/exercises/bob/src/Example.hs
+++ b/exercises/bob/src/Example.hs
@@ -6,7 +6,7 @@ data Prompt = Silence | Yell | Question | Other
 classify :: String -> Prompt
 classify s | all isSpace s = Silence
            | any isAlpha s && (all isUpper $ filter isAlpha s) = Yell
-           | '?' == last s = Question
+           | '?' == last (filter (not . isSpace) s) = Question
            | otherwise = Other
 
 response :: Prompt -> String

--- a/exercises/bob/test/Tests.hs
+++ b/exercises/bob/test/Tests.hs
@@ -1,118 +1,134 @@
-import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), Counts(..))
-import System.Exit (ExitCode(..), exitWith)
+{-# LANGUAGE RecordWildCards #-}
+
+import Data.Foldable     (for_)
+import Test.Hspec        (Spec, describe, it, shouldBe)
+import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+
 import Bob (responseFor)
 
-exitProperly :: IO Counts -> IO ()
-exitProperly m = do
-  counts <- m
-  exitWith $ if failures counts /= 0 || errors counts /= 0 then ExitFailure 1 else ExitSuccess
-
-testCase :: String -> Assertion -> Test
-testCase label assertion = TestLabel label (TestCase assertion)
-
-test_respondsToSomething :: Assertion
-test_respondsToSomething =
-  "Whatever." @=? responseFor "Tom-ay-to, tom-aaaah-to."
-
-test_respondsToShouts :: Assertion
-test_respondsToShouts =
-  "Whoa, chill out!" @=? responseFor "WATCH OUT!"
-
-test_respondsToQuestions :: Assertion
-test_respondsToQuestions =
-  "Sure." @=? responseFor "Does this cryogenic chamber make me look fat?"
-
-test_respondsToForcefulTalking :: Assertion
-test_respondsToForcefulTalking =
-  "Whatever." @=? responseFor "Let's go make out behind the gym!"
-
-test_respondsToAcronyms :: Assertion
-test_respondsToAcronyms =
-  "Whatever." @=? responseFor "It's OK if you don't want to go to the DMV."
-
-test_respondsToForcefulQuestions :: Assertion
-test_respondsToForcefulQuestions =
-  "Whoa, chill out!" @=? responseFor "WHAT THE HELL WERE YOU THINKING?"
-
-test_respondsToShoutingWithSpecialCharacters :: Assertion
-test_respondsToShoutingWithSpecialCharacters =
-  "Whoa, chill out!" @=? responseFor (
-    "ZOMG THE %^*@#$(*^ ZOMBIES ARE COMING!!11!!1!")
-
-test_respondsToShoutingNumbers :: Assertion
-test_respondsToShoutingNumbers =
-  "Whoa, chill out!" @=? responseFor "1, 2, 3 GO!"
-
-test_respondsToShoutingWithNoExclamationMark :: Assertion
-test_respondsToShoutingWithNoExclamationMark =
-  "Whoa, chill out!" @=? responseFor "I HATE YOU"
-
-test_respondsToStatementContainingQuestionMark :: Assertion
-test_respondsToStatementContainingQuestionMark =
-  "Whatever." @=? responseFor "Ending with ? means a question."
-
-test_respondsToSilence :: Assertion
-test_respondsToSilence =
-  "Fine. Be that way!" @=? responseFor ""
-
-test_respondsToProlongedSilence :: Assertion
-test_respondsToProlongedSilence =
-  "Fine. Be that way!" @=? responseFor "    "
-
-test_respondsToNonLettersWithQuestion :: Assertion
-test_respondsToNonLettersWithQuestion =
-  "Sure." @=? responseFor ":) ?"
-
-test_respondsToMultipleLineQuestions :: Assertion
-test_respondsToMultipleLineQuestions =
-  "Whatever." @=? responseFor "\nDoes this cryogenic chamber make me look fat? \nno"
-
-test_respondsToOtherWhitespace :: Assertion
-test_respondsToOtherWhitespace =
-  "Fine. Be that way!" @=? responseFor "\n\r \t\v\xA0\x2002" -- \xA0 No-break space, \x2002 En space
-
-test_respondsToOnlyNumbers :: Assertion
-test_respondsToOnlyNumbers =
-  "Whatever." @=? responseFor "1, 2, 3"
-
-test_respondsToQuestionWithOnlyNumbers :: Assertion
-test_respondsToQuestionWithOnlyNumbers =
-  "Sure." @=? responseFor "4?"
-
-test_respondsToUnicodeShout :: Assertion
-test_respondsToUnicodeShout =
-  "Whoa, chill out!" @=? responseFor "\xdcML\xc4\xdcTS!"
-
-test_respondsToUnicodeNonShout :: Assertion
-test_respondsToUnicodeNonShout =
-  "Whatever." @=? responseFor "\xdcML\xe4\xdcTS!"
-
-respondsToTests :: [Test]
-respondsToTests =
-  [ testCase "something" test_respondsToSomething
-  , testCase "shouts" test_respondsToShouts
-  , testCase "questions" test_respondsToQuestions
-  , testCase "forceful talking" test_respondsToForcefulTalking
-  , testCase "acronyms" test_respondsToAcronyms
-  , testCase "forceful questions" test_respondsToForcefulQuestions
-  , testCase "shouting with special characters"
-    test_respondsToShoutingWithSpecialCharacters
-  , testCase "shouting numbers" test_respondsToShoutingNumbers
-  , testCase "shouting with no exclamation mark"
-    test_respondsToShoutingWithNoExclamationMark
-  , testCase "statement containing question mark"
-    test_respondsToStatementContainingQuestionMark
-  , testCase "silence" test_respondsToSilence
-  , testCase "prolonged silence" test_respondsToProlongedSilence
-  , testCase "questioned nonsense" test_respondsToNonLettersWithQuestion
-  , testCase "multiple-line statement containing question mark"
-    test_respondsToMultipleLineQuestions
-  , testCase "all whitespace is silence" test_respondsToOtherWhitespace
-  , testCase "only numbers" test_respondsToOnlyNumbers
-  , testCase "question with only numbers" test_respondsToQuestionWithOnlyNumbers
-  , testCase "unicode shout" test_respondsToUnicodeShout
-  , testCase "unicode non-shout" test_respondsToUnicodeNonShout
-  ]
-
 main :: IO ()
-main = exitProperly (runTestTT (TestList respondsToTests))
+main = hspecWith defaultConfig {configFastFail = True} specs
+
+specs :: Spec
+specs = describe "bob" $
+          describe "responseFor" $ for_ cases test
+  where
+    test Case{..} = it description $ responseFor input `shouldBe` expected
+
+-- Test cases adapted from `exercism/x-common/bob.json` on 2016-07-24.
+
+data Case = Case { description :: String
+                 , input       :: String
+                 , expected    :: String
+                 }
+
+cases :: [Case]
+cases = [ Case { description = "stating something"
+               , input       = "Tom-ay-to, tom-aaaah-to."
+               , expected    = "Whatever."
+               }
+        , Case { description = "shouting"
+               , input       = "WATCH OUT!"
+               , expected    = "Whoa, chill out!"
+               }
+        , Case { description = "shouting gibberish"
+               , input       = "FCECDFCAAB"
+               , expected    = "Whoa, chill out!"
+               }
+        , Case { description = "asking a question"
+               , input       = "Does this cryogenic chamber make me look fat?"
+               , expected    = "Sure."
+               }
+        , Case { description = "asking a numeric question"
+               , input       = "You are, what, like 15?"
+               , expected    = "Sure."
+               }
+        , Case { description = "asking gibberish"
+               , input       = "fffbbcbeab?"
+               , expected    = "Sure."
+               }
+        , Case { description = "talking forcefully"
+               , input       = "Let's go make out behind the gym!"
+               , expected    = "Whatever."
+               }
+        , Case { description = "using acronyms in regular speech"
+               , input       = "It's OK if you don't want to go to the DMV."
+               , expected    = "Whatever."
+               }
+        , Case { description = "forceful question"
+               , input       = "WHAT THE HELL WERE YOU THINKING?"
+               , expected    = "Whoa, chill out!"
+               }
+        , Case { description = "shouting numbers"
+               , input       = "1, 2, 3 GO!"
+               , expected    = "Whoa, chill out!"
+               }
+        , Case { description = "only numbers"
+               , input       = "1, 2, 3"
+               , expected    = "Whatever."
+               }
+        , Case { description = "question with only numbers"
+               , input       = "4?"
+               , expected    = "Sure."
+               }
+        , Case { description = "shouting with special characters"
+               , input       = "ZOMG THE %^*@#$(*^ ZOMBIES ARE COMING!!11!!1!"
+               , expected    = "Whoa, chill out!"
+               }
+        , Case { description = "shouting with umlauts"
+               , input       = "ÜMLÄÜTS!"
+               , expected    = "Whoa, chill out!"
+               }
+        , Case { description = "calmly speaking with umlauts"
+               , input       = "ÜMLäÜTS!"
+               , expected    = "Whatever."
+               }
+        , Case { description = "shouting with no exclamation mark"
+               , input       = "I HATE YOU"
+               , expected    = "Whoa, chill out!"
+               }
+        , Case { description = "statement containing question mark"
+               , input       = "Ending with ? means a question."
+               , expected    = "Whatever."
+               }
+        , Case { description = "non-letters with question"
+               , input       = ":) ?"
+               , expected    = "Sure."
+               }
+        , Case { description = "prattling on"
+               , input       = "Wait! Hang on. Are you going to be OK?"
+               , expected    = "Sure."
+               }
+        , Case { description = "silence"
+               , input       = ""
+               , expected    = "Fine. Be that way!"
+               }
+        , Case { description = "prolonged silence"
+               , input       = "          "
+               , expected    = "Fine. Be that way!"
+               }
+        , Case { description = "alternate silence"
+               , input       = "\t\t\t\t\t\t\t\t\t\t"
+               , expected    = "Fine. Be that way!"
+               }
+        , Case { description = "multiple line question"
+               , input       = "\nDoes this cryogenic chamber make me look fat?\nno"
+               , expected    = "Whatever."
+               }
+        , Case { description = "starting with whitespace"
+               , input       = "         hmmmmmmm..."
+               , expected    = "Whatever."
+               }
+        , Case { description = "ending with whitespace"
+               , input       = "Okay if like my  spacebar  quite a bit?   "
+               , expected    = "Sure."
+               }
+        , Case { description = "other whitespace"
+               , input       = "\n\r \t\x000b\x00a0\x2002"
+               , expected    = "Fine. Be that way!"
+               }
+        , Case { description = "non-question ending with whitespace"
+               , input       = "This is a statement ending with whitespace      "
+               , expected    = "Whatever."
+               }
+        ]


### PR DESCRIPTION
- Rewrite to use hspec.
- Add tests to match the json file.
- Remove old test not matching the json file.
- Fix solution to work with the new test cases.

Related to #211.
