### PR TITLE
sum-of-multiples: Rewrite tests to use hspec with fail-fast.

### DIFF
--- a/exercises/sum-of-multiples/package.yaml
+++ b/exercises/sum-of-multiples/package.yaml
@@ -16,4 +16,4 @@ tests:
     source-dirs: test
     dependencies:
       - sum-of-multiples
-      - HUnit
+      - hspec


### PR DESCRIPTION
Related to #211.
