### PR TITLE
nucleotide-count: Rewrite to use hspec with fail-fast.

### DIFF
--- a/exercises/nucleotide-count/package.yaml
+++ b/exercises/nucleotide-count/package.yaml
@@ -17,4 +17,4 @@ tests:
     source-dirs: test
     dependencies:
       - nucleotide-count
-      - HUnit
+      - hspec


### PR DESCRIPTION
- Rewrite to use hspec with fail-fast.
- Change tests to make them more polymorphic.

Related to #211.
