### PR TITLE
simple-linked-list: Rewrite tests to use hspec with fail-fast.

### DIFF
--- a/exercises/simple-linked-list/package.yaml
+++ b/exercises/simple-linked-list/package.yaml
@@ -16,4 +16,4 @@ tests:
     source-dirs: test
     dependencies:
       - simple-linked-list
-      - HUnit
+      - hspec

--- a/exercises/simple-linked-list/test/Tests.hs
+++ b/exercises/simple-linked-list/test/Tests.hs
@@ -1,68 +1,77 @@
-import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), Counts(..))
-import System.Exit (ExitCode(..), exitWith)
-import qualified LinkedList as L
+import Test.Hspec        (Spec, describe, it, shouldBe)
+import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
 
-exitProperly :: IO Counts -> IO ()
-exitProperly m = do
-  counts <- m
-  exitWith $ if failures counts /= 0 || errors counts /= 0 then ExitFailure 1 else ExitSuccess
-
-testCase :: String -> Assertion -> Test
-testCase label assertion = TestLabel label (TestCase assertion)
+import LinkedList
+  ( datum
+  , fromList
+  , isNil
+  , next
+  , new
+  , nil
+  , reverseLinkedList
+  , toList
+  )
 
 main :: IO ()
-main = exitProperly $ runTestTT $ TestList
-  [ TestList listTests ]
+main = hspecWith defaultConfig {configFastFail = True} specs
 
-listTests :: [Test]
-listTests =
-  [ testCase "constructor" $ do
-    True @=? L.isNil L.nil
-    False @=? L.isNil one
-    1 @=? L.datum one
-    True @=? L.isNil (L.next one)
-    False @=? L.isNil two
-    2 @=? L.datum two
-    False @=? L.isNil (L.next two)
-    1 @=? L.datum (L.next two)
-    True @=? L.isNil (L.next $ L.next two)
-  , testCase "toList" $ do
-    ([] :: [Int]) @=? L.toList L.nil
-    [1] @=? L.toList one
-    [2, 1] @=? L.toList two
-  , testCase "fromList" $ do
-    True @=? L.isNil (L.fromList [])
-    let one_a = L.fromList [1 :: Int]
-    1 @=? L.datum one_a
-    True @=? L.isNil (L.next one_a)
-    let two_a = L.fromList [2, 1 :: Int]
-    2 @=? L.datum two_a
-    1 @=? L.datum (L.next two_a)
-    True @=? L.isNil (L.next $ L.next two_a)
-  , testCase "reverseList" $ do
-    True @=? L.isNil (L.reverseLinkedList L.nil)
-    let one_r = L.reverseLinkedList one
-    1 @=? L.datum one_r
-    True @=? L.isNil (L.next one_r)
-    let two_r = L.reverseLinkedList two
-    1 @=? L.datum two_r
-    2 @=? L.datum (L.next two_r)
-    True @=? L.isNil (L.next $ L.next two_r)
-    let three_r = L.reverseLinkedList three
-    1 @=? L.datum three_r
-    2 @=? L.datum (L.next three_r)
-    3 @=? L.datum (L.next (L.next three_r))
-  , testCase "roundtrip" $ do
-    ([] :: [Int]) @=? (L.toList . L.fromList) []
-    ([1] :: [Int]) @=? (L.toList . L.fromList) [1]
-    ([1, 2] :: [Int]) @=? (L.toList . L.fromList) [1, 2]
-    ([1..10] :: [Int]) @=? (L.toList . L.fromList) [1..10]
-  , testCase "has an unconstrained type variable" $ do
-    anyTypeMsg @=? (L.toList . L.fromList) anyTypeMsg
-    ([1..10] :: [Integer]) @=? (L.toList . L.fromList) [1..10]
-  ]
-  where
-    one = L.new (1 :: Int) L.nil
-    two = L.new 2 one
-    three = L.new 3 two
-    anyTypeMsg = "Should work for any type, not just Int!"
+specs :: Spec
+specs = describe "simple-linked-list" $ do
+
+            -- As of 2016-07-27, there was no reference file
+            -- for the test cases in `exercism/x-common`.
+
+            let n1   = new (1 :: Int) nil
+            let n21  = new 2 n1
+            let n321 = new 3 n21
+            let fl1  = fromList [1 :: Int]
+            let fl21 = fromList [2, 1 :: Int]
+            let r1   = reverseLinkedList n1
+            let r12  = reverseLinkedList n21
+            let r123 = reverseLinkedList n321
+            let msg  = "Should work for any type, not just Int!"
+
+            it "constructor" $ do
+                isNil nil               `shouldBe` True
+                isNil n1                `shouldBe` False
+                datum n1                `shouldBe` 1
+                isNil (next n1)         `shouldBe` True
+                isNil n21               `shouldBe` False
+                datum n21               `shouldBe` 2
+                isNil (next n21)        `shouldBe` False
+                datum (next n21)        `shouldBe` 1
+                isNil (next $ next n21) `shouldBe` True
+
+            it "toList" $ do
+                toList nil `shouldBe` ([] :: [Int])
+                toList n1  `shouldBe` [1]
+                toList n21 `shouldBe` [2, 1]
+
+            it "fromList" $ do
+                isNil (fromList [])      `shouldBe` True
+                datum fl1                `shouldBe` 1
+                isNil (next fl1)         `shouldBe` True
+                datum fl21               `shouldBe` 2
+                datum (next fl21)        `shouldBe` 1
+                isNil (next $ next fl21) `shouldBe` True
+
+            it "reverseList" $ do
+                isNil (reverseLinkedList nil) `shouldBe` True
+                datum r1                      `shouldBe` 1
+                isNil (next r1)               `shouldBe` True
+                datum r12                     `shouldBe` 1
+                datum (next r12)              `shouldBe` 2
+                isNil (next $ next r12)       `shouldBe` True
+                datum r123                    `shouldBe` 1
+                datum (next r123)             `shouldBe` 2
+                datum (next $ next r123)      `shouldBe` 3
+
+            it "roundtrip" $ do
+                (toList . fromList) []      `shouldBe` ([]      :: [Int])
+                (toList . fromList) [1]     `shouldBe` ([1]     :: [Int])
+                (toList . fromList) [1, 2]  `shouldBe` ([1, 2]  :: [Int])
+                (toList . fromList) [1..10] `shouldBe` ([1..10] :: [Int])
+
+            it "has an unconstrained type variable" $ do
+                (toList . fromList) msg     `shouldBe` msg
+                (toList . fromList) [1..10] `shouldBe` ([1..10] :: [Integer])


### PR DESCRIPTION
Related to #211.
