### PR TITLE
list-ops: Rewrite tests to use hspec with fail-fast.

### DIFF
--- a/exercises/list-ops/package.yaml
+++ b/exercises/list-ops/package.yaml
@@ -16,4 +16,4 @@ tests:
     source-dirs: test
     dependencies:
       - list-ops
-      - HUnit
+      - hspec

--- a/exercises/list-ops/test/Tests.hs
+++ b/exercises/list-ops/test/Tests.hs
@@ -1,82 +1,117 @@
-{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveDataTypeable #-} -- Needed for GHC 7.8.
 
-import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), Counts(..))
-import System.Exit (ExitCode(..), exitWith)
-import qualified ListOps as L
-import Control.Exception (Exception, throw, evaluate, try)
-import Data.Typeable (Typeable)
+import Control.Exception (Exception, throw, evaluate)
+import Data.Typeable     (Typeable) -- Needed for GHC 7.8.
+import Test.Hspec        (Spec, describe, it, shouldBe, shouldThrow)
+import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
 
-data FoldlIsStrictException = FoldlIsStrictException deriving (Eq, Show, Typeable)
-instance Exception FoldlIsStrictException
+import Prelude hiding
+    ( (++)
+    , concat
+    , foldr
+    , length
+    , map
+    , reverse
+    )
 
-exitProperly :: IO Counts -> IO ()
-exitProperly m = do
-  counts <- m
-  exitWith $ if failures counts /= 0 || errors counts /= 0 then ExitFailure 1 else ExitSuccess
+import ListOps
+    ( (++)
+    , concat
+    , foldl'
+    , foldr
+    , length
+    , map
+    , reverse
+    )
 
-testCase :: String -> Assertion -> Test
-testCase label assertion = TestLabel label (TestCase assertion)
+-- We explicitly derive `Typeable` to keep compatibility with GHC 7.8.
+data StrictException = StrictException deriving (Eq, Show, Typeable)
+
+instance Exception StrictException
 
 main :: IO ()
-main = exitProperly $ runTestTT $ TestList
-       [ TestList listOpsTests ]
+main = hspecWith defaultConfig {configFastFail = True} specs
 
+specs :: Spec
+specs = describe "list-ops" $ do
 
-big :: Int
-big = 100000
+    -- As of 2016-07-27, there was no reference file
+    -- for the test cases in `exercism/x-common`.
 
-listOpsTests :: [Test]
-listOpsTests =
-  [ testCase "length of empty list" $ do
-    0 @=? L.length ([] :: [Int])
-  , testCase "length of non-empty list" $ do
-    4 @=? L.length [1 .. 4 :: Int]
-  , testCase "length of large list" $ do
-    big @=? L.length [1 .. big :: Int]
-  , testCase "reverse of empty list" $ do
-    [] @=? L.reverse ([] :: [Int])
-  , testCase "reverse of non-empty list" $ do
-    [100 , 99 .. 1] @=? L.reverse [1 .. 100 :: Int]
-  , testCase "map of empty list" $ do
-    [] @=? L.map (+1) ([] :: [Int])
-  , testCase "map of non-empty list" $ do
-    [2, 4 .. 8] @=? L.map (+1) [1, 3 .. 7 :: Int]
-  , testCase "filter of empty list" $ do
-    [] @=? L.filter undefined ([] :: [Int])
-  , testCase "filter of normal list" $ do
-    [1, 3] @=? L.filter odd [1 .. 4 :: Int]
-  , testCase "foldl' of empty list" $ do
-    0 @=? L.foldl' (+) (0 :: Int) []
-  , testCase "foldl' of non-empty list" $ do
-    7 @=? L.foldl' (+) (-3) [1 .. 4 :: Int]
-  , testCase "foldl' of huge list" $ do
-    big * (big + 1) `div` 2 @=? L.foldl' (+) 0 [1 .. big]
-  , testCase "foldl' with non-commutative function" $ do
-    0 @=? L.foldl' (-) 10 [1 .. 4 :: Int]
-  , testCase "foldl' is not just foldr . flip" $ do
-    "fdsa" @=? L.foldl' (flip (:)) [] "asdf"
-  , testCase "foldl' is accumulator-strict (use seq or BangPatterns)" $ do
-    r <- try . evaluate $
-      L.foldl' (flip const) () [throw FoldlIsStrictException, ()]
-    Left FoldlIsStrictException @=? (r :: Either FoldlIsStrictException ())
-  , testCase "foldr as id" $ do
-    [1 .. big] @=? L.foldr (:) [] [1 .. big]
-  , testCase "foldr as append" $ do
-    [1 .. big] @=? L.foldr (:) [100 .. big] [1 .. 99]
-  , testCase "++ of empty lists" $ do
-    [] @=? [] L.++ ([] :: [Int])
-  , testCase "++ of empty and non-empty lists" $ do
-    [1 .. 4] @=? [] L.++ [1 .. 4 :: Int]
-  , testCase "++ of non-empty and empty lists" $ do
-    [1 .. 4] @=? [1 .. 4 :: Int] L.++ []
-  , testCase "++ of non-empty lists" $ do
-    [1 .. 5] @=? [1 .. 3] L.++ [4, 5 :: Int]
-  , testCase "++ of large lists" $ do
-    [1 .. big] @=? [1 .. big `div` 2] L.++ [1 + big `div` 2 .. big]
-  , testCase "concat of no lists" $ do
-    [] @=? L.concat ([] :: [[Int]])
-  , testCase "concat of list of lists" $ do
-    [1 .. 6] @=? L.concat [[1, 2], [3], [], [4, 5, 6 :: Int]]
-  , testCase "concat of large list of small lists" $ do
-    [1 .. big] @=? L.concat (map (:[]) [1 .. big])
-  ]
+    let big = 100000 :: Int
+
+    it "length of empty list" $
+      length ([] :: [Int]) `shouldBe` 0
+
+    it "length of non-empty list" $
+      length [1 .. 4 :: Int] `shouldBe` 4
+
+    it "length of large list" $
+      length [1 .. big :: Int] `shouldBe` big
+
+    it "reverse of empty list" $
+      reverse ([] :: [Int]) `shouldBe` []
+
+    it "reverse of non-empty list" $
+      reverse [1 .. 100 :: Int] `shouldBe` [100 , 99 .. 1]
+
+    it "map of empty list" $
+      map (+1) ([] :: [Int]) `shouldBe` []
+
+    it "map of non-empty list" $
+      map (+1) [1, 3 .. 7 :: Int] `shouldBe` [2, 4 .. 8]
+
+    it "filter of empty list" $
+      filter undefined ([] :: [Int]) `shouldBe` []
+
+    it "filter of normal list" $
+      filter odd [1 .. 4 :: Int] `shouldBe` [1, 3]
+
+    it "foldl' of empty list" $
+      foldl' (+) (0 :: Int) [] `shouldBe` 0
+
+    it "foldl' of non-empty list" $
+      foldl' (+) (-3) [1 .. 4 :: Int] `shouldBe` 7
+
+    it "foldl' of huge list" $
+      foldl' (+) 0 [1 .. big] `shouldBe` big * (big + 1) `div` 2
+
+    it "foldl' with non-commutative function" $
+      foldl' (-) 10 [1 .. 4 :: Int] `shouldBe` 0
+
+    it "foldl' is not just foldr . flip" $
+      foldl' (flip (:)) [] "asdf" `shouldBe` "fdsa"
+
+    it "foldl' is accumulator-strict (use seq or BangPatterns)" $
+      evaluate (foldl' (flip const) () [throw StrictException, ()])
+      `shouldThrow` (== StrictException)
+
+    it "foldr as id" $
+      foldr (:) [] [1 .. big] `shouldBe` [1 .. big]
+
+    it "foldr as append" $
+      foldr (:) [100 .. big] [1 .. 99] `shouldBe` [1 .. big]
+
+    it "++ of empty lists" $
+      [] ++ ([] :: [Int]) `shouldBe` []
+
+    it "++ of empty and non-empty lists" $
+      [] ++ [1 .. 4 :: Int] `shouldBe` [1 .. 4]
+
+    it "++ of non-empty and empty lists" $
+      [1 .. 4 :: Int] ++ [] `shouldBe` [1 .. 4]
+
+    it "++ of non-empty lists" $
+      [1 .. 3] ++ [4, 5 :: Int] `shouldBe` [1 .. 5]
+
+    it "++ of large lists" $
+      [1 .. big `div` 2] ++ [1 + big `div` 2 .. big] `shouldBe` [1 .. big]
+
+    it "concat of no lists" $
+      concat ([] :: [[Int]]) `shouldBe` []
+
+    it "concat of list of lists" $
+      concat [[1, 2], [3], [], [4, 5, 6 :: Int]] `shouldBe` [1 .. 6]
+
+    it "concat of large list of small lists" $
+      concat (map (:[]) [1 .. big]) `shouldBe` [1 .. big]


### PR DESCRIPTION
Related to #211.
