### PR TITLE
gigasecond: Rewrite tests to use hspec with fail-fast.

### DIFF
--- a/exercises/gigasecond/package.yaml
+++ b/exercises/gigasecond/package.yaml
@@ -17,5 +17,5 @@ tests:
     source-dirs: test
     dependencies:
       - gigasecond
-      - HUnit
+      - hspec
       - old-locale

--- a/exercises/gigasecond/test/Tests.hs
+++ b/exercises/gigasecond/test/Tests.hs
@@ -1,39 +1,52 @@
 {-# LANGUAGE CPP #-}
-import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), Counts(..))
-import System.Exit (ExitCode(..), exitWith)
+
+import Data.Time.Clock   (UTCTime)
+import Test.Hspec        (Spec, describe, it, shouldBe)
+import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+
 import Gigasecond (fromDay)
-import Data.Time.Clock (UTCTime)
-#if __GLASGOW_HASKELL__ >= 710
-import Data.Time.Format (TimeLocale, ParseTime, parseTimeOrError, defaultTimeLocale, iso8601DateFormat)
+
+#if MIN_VERSION_time(1,5,0)
+
+import Data.Time.Format
+  ( ParseTime
+  , TimeLocale
+  , defaultTimeLocale
+  , iso8601DateFormat
+  , parseTimeOrError
+  )
+
 readTime :: ParseTime t => TimeLocale -> String -> String -> t
 readTime = parseTimeOrError True
+
 #else
-import System.Locale (defaultTimeLocale, iso8601DateFormat)
+
 import Data.Time.Format (readTime)
+import System.Locale    (defaultTimeLocale, iso8601DateFormat)
+
 #endif
 
-dt :: String -> UTCTime
-dt = readTime defaultTimeLocale (iso8601DateFormat (Just "%T%Z"))
-
-exitProperly :: IO Counts -> IO ()
-exitProperly m = do
-  counts <- m
-  exitWith $ if failures counts /= 0 || errors counts /= 0 then ExitFailure 1 else ExitSuccess
-
-testCase :: String -> Assertion -> Test
-testCase label assertion = TestLabel label (TestCase assertion)
-
 main :: IO ()
-main = exitProperly $ runTestTT $ TestList
-       [ TestList gigasecondTests ]
+main = hspecWith defaultConfig {configFastFail = True} specs
 
-gigasecondTests :: [Test]
-gigasecondTests =
-  [ testCase "from apr 25 2011" $
-    dt "2043-01-01T01:46:40Z" @=? fromDay (dt "2011-04-25T00:00:00Z")
-  , testCase "from jun 13 1977" $
-    dt "2009-02-19T01:46:40Z" @=? fromDay (dt "1977-06-13T00:00:00Z")
-  , testCase "from jul 19 1959" $
-    dt "1991-03-27T01:46:40Z" @=? fromDay (dt "1959-07-19T00:00:00Z")
-    -- customize this to test your birthday and find your gigasecond date:
-  ]
+specs :: Spec
+specs = describe "gigasecond" $
+          describe "fromDay" $ do
+
+            -- Test cases loosely based on reference file
+            -- at `exercism/x-common/gigasecond.json`.
+
+            let dt = readTime defaultTimeLocale
+                     (iso8601DateFormat (Just "%T%Z")) :: String -> UTCTime
+
+            it "from apr 25 2011" $
+              fromDay (dt "2011-04-25T00:00:00Z")
+              `shouldBe` dt "2043-01-01T01:46:40Z"
+
+            it "from jun 13 1977" $
+              fromDay (dt "1977-06-13T00:00:00Z")
+              `shouldBe` dt "2009-02-19T01:46:40Z"
+
+            it "from jul 19 1959" $
+              fromDay (dt "1959-07-19T00:00:00Z")
+              `shouldBe` dt "1991-03-27T01:46:40Z"


### PR DESCRIPTION
Related to #211.
