### PR TITLE
etl: Rewrite tests to use hspec with fail-fast.

### DIFF
--- a/exercises/etl/package.yaml
+++ b/exercises/etl/package.yaml
@@ -17,4 +17,4 @@ tests:
     source-dirs: test
     dependencies:
       - etl
-      - HUnit
+      - hspec

--- a/exercises/etl/test/Tests.hs
+++ b/exercises/etl/test/Tests.hs
@@ -1,51 +1,52 @@
 {-# OPTIONS_GHC -fno-warn-type-defaults #-}
 
-import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), Counts(..))
-import System.Exit (ExitCode(..), exitWith)
+import Data.Map          (fromList)
+import Test.Hspec        (Spec, describe, it, shouldBe)
+import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+
 import ETL (transform)
-import qualified Data.Map as M
-
-exitProperly :: IO Counts -> IO ()
-exitProperly m = do
-  counts <- m
-  exitWith $ if failures counts /= 0 || errors counts /= 0 then ExitFailure 1 else ExitSuccess
-
-testCase :: String -> Assertion -> Test
-testCase label assertion = TestLabel label (TestCase assertion)
 
 main :: IO ()
-main = exitProperly $ runTestTT $ TestList
-       [ TestList transformTests ]
+main = hspecWith defaultConfig {configFastFail = True} specs
 
-transformTests :: [Test]
-transformTests =
-  [ testCase "transform one value" $
-    M.fromList [('a', 1)] @=? transform (M.fromList [(1, "A")])
-  , testCase "transform multiple keys from one value" $
-    M.fromList [('a', 1), ('e', 1)] @=? transform (M.fromList [(1, "AE")])
-  , testCase "transform multiple keys from multiple values" $
-    M.fromList [('a', 1), ('b', 4)] @=?
-    transform (M.fromList [(1, "A"), (4, "B")])
-  , testCase "full dataset" $
-    M.fromList fullOut @=? transform (M.fromList fullIn)
-  ]
+specs :: Spec
+specs = describe "etl" $
 
-fullOut :: [(Char, Int)]
-fullOut =
-  [ ('a', 1), ('b', 3), ('c', 3), ('d', 2), ('e', 1)
-  , ('f', 4), ('g', 2), ('h', 4), ('i', 1), ('j', 8)
-  , ('k', 5), ('l', 1), ('m', 3), ('n', 1), ('o', 1)
-  , ('p', 3), ('q', 10), ('r', 1), ('s', 1), ('t', 1)
-  , ('u', 1), ('v', 4), ('w', 4), ('x', 8), ('y', 4)
-  , ('z', 10) ]
+  -- As of 2016-07-27, there was no reference file
+  -- for the test cases in `exercism/x-common`.
 
-fullIn :: [(Int, String)]
-fullIn =
-  [ (1, "AEIOULNRST")
-  , (2, "DG")
-  , (3, "BCMP")
-  , (4, "FHVWY")
-  , (5, "K")
-  , (8, "JX")
-  , (10,"QZ")
-  ]
+  describe "transform" $ do
+
+    it "transform one value" $
+      transform (fromList [(1, "A")])
+      `shouldBe` fromList [('a', 1)]
+
+    it "transform multiple keys from one value" $
+      transform (fromList [(1, "AE")])
+      `shouldBe` fromList [('a', 1), ('e', 1)]
+
+    it "transform multiple keys from multiple values" $
+      transform (fromList [(1, "A"), (4, "B")])
+      `shouldBe` fromList [('a', 1), ('b', 4)]
+
+    it "full dataset" $
+      transform (fromList fullInput)
+      `shouldBe` fromList fullOutput
+
+  where
+
+    fullInput = [ ( 1, "AEIOULNRST")
+                , ( 2, "DG"        )
+                , ( 3, "BCMP"      )
+                , ( 4, "FHVWY"     )
+                , ( 5, "K"         )
+                , ( 8, "JX"        )
+                , (10, "QZ"        ) ]
+
+    fullOutput = [ ('a',  1) , ('b',  3) , ('c',  3) , ('d',  2)
+                 , ('e',  1) , ('f',  4) , ('g',  2) , ('h',  4)
+                 , ('i',  1) , ('j',  8) , ('k',  5) , ('l',  1)
+                 , ('m',  3) , ('n',  1) , ('o',  1) , ('p',  3)
+                 , ('q', 10) , ('r',  1) , ('s',  1) , ('t',  1)
+                 , ('u',  1) , ('v',  4) , ('w',  4) , ('x',  8)
+                 , ('y',  4) , ('z', 10) ]


### PR DESCRIPTION
Related to #211.
