### PR TITLE
allergies: Rewrite tests to use hspec with fail-fast.

### DIFF
--- a/exercises/allergies/package.yaml
+++ b/exercises/allergies/package.yaml
@@ -16,4 +16,4 @@ tests:
     source-dirs: test
     dependencies:
       - allergies
-      - HUnit
+      - hspec


### PR DESCRIPTION
- Rewrite tests to use hspec.
- Fixed to allow allergens to be returned in any order.
- Fixed to supress warning on polymorphic solutions.

Related to #211.
