### PR TITLE
atbash-cipher: Rewrite tests to use hspec with fail-fast.

### DIFF
--- a/exercises/atbash-cipher/package.yaml
+++ b/exercises/atbash-cipher/package.yaml
@@ -17,4 +17,4 @@ tests:
     source-dirs: test
     dependencies:
       - atbash-cipher
-      - HUnit
+      - hspec

--- a/exercises/atbash-cipher/src/Atbash.hs
+++ b/exercises/atbash-cipher/src/Atbash.hs
@@ -1,4 +1,7 @@
-module Atbash (encode) where
+module Atbash (decode, encode) where
+
+decode :: String -> String
+decode = undefined
 
 encode :: String -> String
 encode = undefined

--- a/exercises/atbash-cipher/src/Example.hs
+++ b/exercises/atbash-cipher/src/Example.hs
@@ -1,14 +1,22 @@
-module Atbash (encode) where
-import Data.Char (isDigit, toLower)
-import Data.Maybe (mapMaybe)
-import Data.List.Split (chunksOf)
+module Atbash (decode, encode) where
 
-cipher :: Char -> Maybe Char
-cipher c | isDigit c              = Just c
-         | lc >= 'a' && lc <= 'z' = Just rotated
-         | otherwise              = Nothing
-  where lc = toLower c
-        rotated = toEnum $ fromEnum 'z' - fromEnum lc + fromEnum 'a'
+import Data.Char       (isAsciiLower, isDigit, toLower)
+import Data.List.Split (chunksOf)
+import Data.Maybe      (mapMaybe)
+
+decode :: String -> String
+decode = mapMaybe atbashChar
 
 encode :: String -> String
-encode = unwords . chunksOf 5 . mapMaybe cipher
+encode = unwords . chunksOf 5 . mapMaybe atbashChar
+
+atbashChar :: Char -> Maybe Char
+atbashChar c
+    | isDigit c       = Just c
+    | isAsciiLower lc = Just symmetric
+    | otherwise       = Nothing
+  where
+    lc = toLower c
+    symmetric = toEnum $ fromEnum 'a'
+                       + fromEnum 'z'
+                       - fromEnum lc

--- a/exercises/atbash-cipher/test/Tests.hs
+++ b/exercises/atbash-cipher/test/Tests.hs
@@ -1,26 +1,84 @@
-import Test.HUnit ((@=?), runTestTT, Test(..), Counts(..))
-import System.Exit (ExitCode(..), exitWith)
-import Atbash (encode)
+{-# LANGUAGE RecordWildCards #-}
 
-exitProperly :: IO Counts -> IO ()
-exitProperly m = do
-  counts <- m
-  exitWith $ if failures counts /= 0 || errors counts /= 0 then ExitFailure 1 else ExitSuccess
+import Data.Foldable     (for_)
+import Test.Hspec        (Spec, describe, it, shouldBe)
+import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+
+import Atbash (encode, decode)
 
 main :: IO ()
-main = exitProperly $ runTestTT $ TestList
-       [ TestList atbashTests ]
+main = hspecWith defaultConfig {configFastFail = True} specs
 
-atbashTests :: [Test]
-atbashTests = map TestCase
-  [ "ml" @=? encode "no"
-  , "bvh" @=? encode "yes"
-  , "lnt" @=? encode "OMG"
-  , "lnt" @=? encode "O M G"
-  , "nrmwy oldrm tob" @=? encode "mindblowingly"
-  , "gvhgr mt123 gvhgr mt" @=? encode "Testing, 1 2 3, testing."
-  , "gifgs rhurx grlm" @=? encode "Truth is fiction."
-  , "gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt" @=?
-    encode "The quick brown fox jumps over the lazy dog."
-  , "mlmzh xrrrt mlivw" @=? encode "non ascii éignored"
-  ]
+specs :: Spec
+specs = describe "atbash-cipher" $ do
+          describe "encode" $ for_ encodeCases $ test encode
+          describe "decode" $ for_ decodeCases $ test decode
+  where
+    test f Case{..} = it description $ f phrase `shouldBe` expected
+
+-- Test cases adapted from `exercism/x-common/atbash-cipher.json` on 2016-08-02.
+
+data Case = Case { description :: String
+                 , phrase      :: String
+                 , expected    :: String
+                 }
+
+encodeCases :: [Case]
+encodeCases =
+    [ Case { description = "encode yes"
+           , phrase      = "yes"
+           , expected    = "bvh"
+           }
+    , Case { description = "encode no"
+           , phrase      = "no"
+           , expected    = "ml"
+           }
+    , Case { description = "encode OMG"
+           , phrase      = "OMG"
+           , expected    = "lnt"
+           }
+    , Case { description = "encode spaces"
+           , phrase      = "O M G"
+           , expected    = "lnt"
+           }
+    , Case { description = "encode mindblowingly"
+           , phrase      = "mindblowingly"
+           , expected    = "nrmwy oldrm tob"
+           }
+    , Case { description = "encode numbers"
+           , phrase      = "Testing,1 2 3, testing."
+           , expected    = "gvhgr mt123 gvhgr mt"
+           }
+    , Case { description = "encode deep thought"
+           , phrase      = "Truth is fiction."
+           , expected    = "gifgs rhurx grlm"
+           }
+    , Case { description = "encode all the letters"
+           , phrase      = "The quick brown fox jumps over the lazy dog."
+           , expected    = "gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt"
+           }
+    , Case { description = "encode ignores non ascii"
+           , phrase      = "non ascii éignored"
+           , expected    = "mlmzh xrrrt mlivw"
+           }
+    ]
+
+decodeCases :: [Case]
+decodeCases =
+    [ Case { description = "decode exercism"
+           , phrase      = "vcvix rhn"
+           , expected    = "exercism"
+           }
+    , Case { description = "decode a sentence"
+           , phrase      = "zmlyh gzxov rhlug vmzhg vkkrm thglm v"
+           , expected    = "anobstacleisoftenasteppingstone"
+           }
+    , Case { description = "decode numbers"
+           , phrase      = "gvhgr mt123 gvhgr mt"
+           , expected    = "testing123testing"
+           }
+    , Case { description = "decode all the letters"
+           , phrase      = "gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt"
+           , expected    = "thequickbrownfoxjumpsoverthelazydog"
+           }
+    ]


### PR DESCRIPTION
- Rewrite tests to use `hspec`.
- Update tests to match `x-common`.
- Add `decode` function to the tests.
- Add `decode` to the stub solution.
- Rewrite the example solution to pass the new tests.

Related to #211.