### PR TITLE
crypto-square: Rewrite tests to use hspec with fail-fast.

### DIFF
--- a/exercises/crypto-square/package.yaml
+++ b/exercises/crypto-square/package.yaml
@@ -17,4 +17,4 @@ tests:
     source-dirs: test
     dependencies:
       - crypto-square
-      - HUnit
+      - hspec

--- a/exercises/crypto-square/src/CryptoSquare.hs
+++ b/exercises/crypto-square/src/CryptoSquare.hs
@@ -3,7 +3,6 @@ module CryptoSquare
     , normalizeCiphertext
     , normalizePlaintext
     , plaintextSegments
-    , squareSize
     ) where
 
 ciphertext :: String -> String
@@ -14,9 +13,6 @@ normalizeCiphertext = undefined
 
 normalizePlaintext :: String -> String
 normalizePlaintext = undefined
-
-squareSize :: String -> Int
-squareSize = undefined
 
 plaintextSegments :: String -> [String]
 plaintextSegments = undefined

--- a/exercises/crypto-square/src/Example.hs
+++ b/exercises/crypto-square/src/Example.hs
@@ -1,5 +1,4 @@
 module CryptoSquare ( normalizePlaintext
-                    , squareSize
                     , plaintextSegments
                     , ciphertext
                     , normalizeCiphertext ) where

--- a/exercises/crypto-square/test/Tests.hs
+++ b/exercises/crypto-square/test/Tests.hs
@@ -1,60 +1,93 @@
-import Test.HUnit ((@=?), runTestTT, Test(..), Counts(..))
-import System.Exit (ExitCode(..), exitWith)
-import CryptoSquare (normalizePlaintext,
-                     squareSize,
-                     plaintextSegments,
-                     ciphertext,
-                     normalizeCiphertext)
+import Test.Hspec        (Spec, describe, it, shouldBe)
+import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
 
-exitProperly :: IO Counts -> IO ()
-exitProperly m = do
-  counts <- m
-  exitWith $ if failures counts /= 0 || errors counts /= 0 then ExitFailure 1 else ExitSuccess
+import CryptoSquare
+  ( ciphertext
+  , normalizeCiphertext 
+  , normalizePlaintext
+  , plaintextSegments
+  )
 
 main :: IO ()
-main = exitProperly $ runTestTT $ TestList
-       [ TestLabel "normalizePlaintext" $ TestList normalizePlaintextTests
-       , TestLabel "squareSize" $ TestList squareSizeTests
-       , TestLabel "plaintextSegments" $ TestList plaintextSegmentsTests
-       , TestLabel "ciphertext" $ TestList ciphertextTests
-       , TestLabel "normalizeCiphertext" $ TestList normalizeCiphertextTests
-       ]
+main = hspecWith defaultConfig {configFastFail = True} specs
 
-normalizePlaintextTests :: [Test]
-normalizePlaintextTests = map TestCase
-  [ "splunk" @=? normalizePlaintext "s#!@$%plunk"
-  , "123go" @=? normalizePlaintext "1, 2, 3 GO!"
-  ]
+specs :: Spec
+specs = describe "crypto-square" $ do
 
-squareSizeTests :: [Test]
-squareSizeTests = map TestCase
-  [ 2 @=? squareSize "1234"
-  , 3 @=? squareSize "123456789"
-  , 4 @=? squareSize "123456789abc" ]
+    -- Test cases adapted from `exercism/x-common/crypto-square.json`
+    -- on 2016-08-02. Some deviations exist and are noted in comments.
 
-plaintextSegmentsTests :: [Test]
-plaintextSegmentsTests = map TestCase
-  [ ["neverv", "exthin", "eheart", "withid", "lewoes"] @=?
-    plaintextSegments "Never vex thine heart with idle woes."
-  , ["zomg", "zomb", "ies"] @=?
-    plaintextSegments "ZOMG! ZOMBIES!!!"
-  ]
+    describe "normalizePlaintext" $ do
 
-ciphertextTests :: [Test]
-ciphertextTests = map TestCase
-  [ "tasneyinicdsmiohooelntuillibsuuml" @=?
-    ciphertext "Time is an illusion. Lunchtime doubly so."
-  , "wneiaweoreneawssciliprerlneoidktcms" @=?
-    ciphertext "We all know interspecies romance is weird."
-  ]
+      it "Lowercase" $
+          normalizePlaintext "Hello"
+          `shouldBe`         "hello"
 
-normalizeCiphertextTests :: [Test]
-normalizeCiphertextTests = map TestCase
-  [ "msemo aanin dnin ndla etlt shui" @=?
-    normalizeCiphertext "Madness, and then illumination."
-  , "vrel aepe mset paoo irpo" @=?
-     normalizeCiphertext "Vampires are people too!"
-  , "imtgdvs fearwer mayoogo anouuio ntnnlvt wttddes aohghn sseoau" @=?
-     normalizeCiphertext "If man was meant to stay on the ground god would \
-                         \have given us roots"
-  ]
+      it "Remove spaces" $
+          normalizePlaintext "Hi there"
+          `shouldBe`         "hithere"
+
+      it "Remove punctuation" $
+          normalizePlaintext "@1, 2%, 3 Go!"
+          `shouldBe`         "123go"
+
+    describe "plaintextSegments" $ do
+
+      it "empty plaintext results in an empty rectangle" $
+          plaintextSegments ""
+          `shouldBe`        []
+
+      it "4 character plaintext results in an 2x2 rectangle" $
+          plaintextSegments "Ab Cd"
+          `shouldBe`        [ "ab"
+                            , "cd" ]
+
+      it "9 character plaintext results in an 3x3 rectangle" $
+          plaintextSegments "This is fun!"
+          `shouldBe`        [ "thi"
+                            , "sis"
+                            , "fun" ]
+
+      it "54 character plaintext results in an 8x7 rectangle" $
+          plaintextSegments "If man was meant to stay on the ground, god would have given us roots."
+          `shouldBe`        [ "ifmanwas"
+                            , "meanttos"
+                            , "tayonthe"
+                            , "groundgo"
+                            , "dwouldha"
+                            , "vegivenu"
+                            , "sroots"  ]
+
+    describe "ciphertext" $ do
+
+    -- The function described by the reference file in `x-common`
+    -- as `encoded` is called `ciphertext` in this track.
+
+      it "empty plaintext results in an empty encode" $
+          ciphertext ""
+          `shouldBe` ""
+
+      it "Non-empty plaintext results in the combined plaintext segments" $
+          ciphertext "If man was meant to stay on the ground, god would have given us roots."
+          `shouldBe` "imtgdvsfearwermayoogoanouuiontnnlvtwttddesaohghnsseoau"
+
+    describe "normalizeCiphertext" $ do
+
+    -- The function described by the reference file in `x-common`
+    -- as `ciphertext` is called `normalizeCiphertext` in this track.
+
+      it "empty plaintext results in an empty ciphertext" $
+          normalizeCiphertext ""
+          `shouldBe`          ""
+
+      it "9 character plaintext results in 3 chunks of 3 characters" $
+          normalizeCiphertext "This is fun!"
+          `shouldBe`          "tsf hiu isn"
+
+    {- In this track the encoded text chunks are not padded with spaces.
+
+      it "54 character plaintext results in 7 chunks, the last two padded with spaces" $
+          normalizeCiphertext "If man was meant to stay on the ground, god would have given us roots."
+          `shouldBe`          "imtgdvs fearwer mayoogo anouuio ntnnlvt wttddes aohghn  sseoau "
+
+    -}


### PR DESCRIPTION
- Rewrite tests to use hspec.
- Remove old tests.
- Add tests to match `x-common`.
- Remove function `squareSize` from the test suite.
- Remove function `squareSize` from the stub solution.
- Remove function `squareSize` from example's export list.

Related to #211.
