### PR TITLE
robot-simulator: Rewrite tests to use hspec with fail-fast.

### DIFF
--- a/exercises/robot-simulator/package.yaml
+++ b/exercises/robot-simulator/package.yaml
@@ -16,4 +16,4 @@ tests:
     source-dirs: test
     dependencies:
       - robot-simulator
-      - HUnit
+      - hspec

--- a/exercises/robot-simulator/src/Example.hs
+++ b/exercises/robot-simulator/src/Example.hs
@@ -1,5 +1,4 @@
 module Robot (Bearing(..),
-              Robot,
               mkRobot,
               coordinates,
               bearing,

--- a/exercises/robot-simulator/src/Robot.hs
+++ b/exercises/robot-simulator/src/Robot.hs
@@ -1,6 +1,5 @@
 module Robot
-    ( Bearing (..)
-    , Robot
+    ( Bearing(East,North,South,West)
     , bearing
     , coordinates
     , mkRobot
@@ -15,8 +14,8 @@ data Bearing = North
              | West
              deriving (Eq, Show)
 
--- The task is to create the data type `Robot`, with `Eq`
--- and `Show` instances, and implement the functions below.
+-- The task is to create the data type `Robot`
+-- and implement the functions below.
 
 bearing :: Robot -> Bearing
 bearing = undefined

--- a/exercises/robot-simulator/test/Tests.hs
+++ b/exercises/robot-simulator/test/Tests.hs
@@ -1,48 +1,105 @@
-import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), Counts(..))
-import System.Exit (ExitCode(..), exitWith)
-import Robot (Bearing(..), Robot, mkRobot,
-              coordinates, simulate,
-              bearing, turnRight, turnLeft)
+{-# OPTIONS_GHC -fno-warn-type-defaults #-}
 
-exitProperly :: IO Counts -> IO ()
-exitProperly m = do
-  counts <- m
-  exitWith $ if failures counts /= 0 || errors counts /= 0 then ExitFailure 1 else ExitSuccess
+import Test.Hspec        (Spec, describe, it, shouldBe)
+import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
 
-testCase :: String -> Assertion -> Test
-testCase label assertion = TestLabel label (TestCase assertion)
+import Robot
+  ( Bearing ( East
+            , North
+            , South
+            , West
+            )
+  , bearing
+  , coordinates
+  , mkRobot
+  , simulate
+  , turnLeft
+  , turnRight
+  )
 
 main :: IO ()
-main = exitProperly $ runTestTT $ TestList
-  [ TestList robotTests ]
+main = hspecWith defaultConfig {configFastFail = True} specs
 
-robotTests :: [Test]
-robotTests =
-  [ testCase "turning cases" $ do
-    West  @=? turnLeft North
-    South @=? turnLeft West
-    East  @=? turnLeft South
-    North @=? turnLeft East
-    East  @=? turnRight North
-    South @=? turnRight East
-    West  @=? turnRight South
-    North @=? turnRight West
-  , testCase "robbie" $ do
-    let robbie :: Robot
-        robbie = mkRobot East (-2, 1)
-    East @=? bearing robbie
-    (-2, 1) @=? coordinates robbie
-    let movedRobbie = simulate robbie "RLAALAL"
-    West @=? bearing movedRobbie
-    (0, 2) @=? coordinates movedRobbie
-    mkRobot West (0, 2) @=? movedRobbie
-  , testCase "clutz" $ do
-    let clutz = mkRobot North (0, 0)
-    mkRobot West (-4, 1) @=? simulate clutz "LAAARALA"
-  , testCase "sphero" $ do
-    let sphero = mkRobot East (2, -7)
-    mkRobot South (-3, -8) @=? simulate sphero "RRAAAAALA"
-  , testCase "roomba" $ do
-    let roomba = mkRobot South (8, 4)
-    mkRobot North (11, 5) @=? simulate roomba "LAAARRRALLLL"
-  ]
+specs :: Spec
+specs = describe "robot-simulator" $ do
+
+    -- Test cases adapted from `exercism/x-common/robot-simulator.json`
+    -- on 2016-08-02. Some deviations exist and are noted in comments.
+
+    describe "mkRobot" $ do
+
+    -- The function described by the reference file
+    -- as `create` is called `mkRobot` in this track.
+
+      it "A robot is created with a position and a direction" $ do
+        let robot = mkRobot North (0, 0)
+        coordinates robot `shouldBe` (0, 0)
+        bearing     robot `shouldBe` North
+
+      it "Negative positions are allowed" $ do
+        let robot = mkRobot South (-1, -1)
+        coordinates robot `shouldBe` (-1, -1)
+        bearing     robot `shouldBe` South
+
+    -- The reference tests for `turnLeft` and `turnRight` describe
+    -- functions that are applied to robots positioned at (0, 0).
+    -- In this track, they are functions over directions, so those
+    -- test cases cannot be completely implemented.
+
+    describe "turnRight" $ do
+
+      it "turn from North" $ turnRight North `shouldBe` East
+      it "turn from East"  $ turnRight East  `shouldBe` South
+      it "turn from South" $ turnRight South `shouldBe` West
+      it "turn from West"  $ turnRight West  `shouldBe` North
+
+    describe "turnLeft" $ do
+
+      it "turn from North" $ turnLeft North `shouldBe` West
+      it "turn from West"  $ turnLeft West  `shouldBe` South
+      it "turn from South" $ turnLeft South `shouldBe` East
+      it "turn from East"  $ turnLeft East  `shouldBe` North
+
+    describe "simulate advance" $ do
+
+    -- The function described by the reference file as `advance`
+    -- doesn't exist in this track, so we test `simulate` with "A".
+
+      let dir `from` pos = simulate (mkRobot dir pos) "A"
+
+      it "does not change the direction" $
+        bearing (North `from` (0, 0)) `shouldBe` North
+
+      it "increases the y coordinate one when facing north" $
+        coordinates (North `from` (0, 0)) `shouldBe` (0, 1)
+
+      it "decreases the y coordinate by one when facing south" $
+        coordinates (South `from` (0, 0)) `shouldBe` (0, -1)
+
+      it "increases the x coordinate by one when facing east" $
+        coordinates (East `from` (0, 0)) `shouldBe` (1, 0)
+
+      it "decreases the x coordinate by one when facing west" $
+        coordinates (West `from` (0, 0)) `shouldBe `(-1, 0)
+
+    describe "simulate" $ do
+
+    -- The function described by the reference file as
+    -- `instructions` is called `simulate` in this track.
+
+      let simulation pos dir = simulate (mkRobot dir pos)
+
+      it "instructions to move west and north" $ do
+        let robot = simulation (0, 0) North "LAAARALA"
+        coordinates robot `shouldBe` (-4, 1)
+        bearing     robot `shouldBe` West
+
+      it "instructions to move west and south" $ do
+        let robot = simulation (2, -7) East "RRAAAAALA"
+        coordinates robot `shouldBe` (-3, -8)
+        bearing     robot `shouldBe` South
+
+      it "instructions to move east and north" $ do
+        let robot = simulation (8, 4) South "LAAARRRALLLL"
+        coordinates robot `shouldBe` (11, 5)
+        bearing     robot `shouldBe` North


### PR DESCRIPTION
- Rewrite tests to use `hspec`.
- Remove old tests.
- Add tests to match `x-common`.
- Remove import of `Robot` in test suite.
- Remove export of `Robot` in example solution.
- Remove export of `Robot` in stub solution.
- Remove instructions to derive `(Eq, Ord)` in stub.

Related to #211.

This exercise is too distant from what is defined in `x-common`, so it will probably be good to rewrite it. I tried to leave comments about the deviations to make the task easier.

I also simplified the interface so that it's not necessary to export the `Robot` data type. This is recommended for better modularization and allows more creative solutions.