### PR TITLE
queen-attack: Rewrite tests to use hspec with fail-fast.

### DIFF
--- a/exercises/queen-attack/package.yaml
+++ b/exercises/queen-attack/package.yaml
@@ -16,4 +16,4 @@ tests:
     source-dirs: test
     dependencies:
       - queen-attack
-      - HUnit
+      - hspec


### PR DESCRIPTION
- Rewrite tests to use `hspec`.
- Update `canAttack` tests to match `x-common`
- Suppress test suite warning on polymorphic solutions.

Related to #211.

The exercise matches only partially the JSON file, because it doesn't have a functions to create queens. That function would probably make more sense in a object-oriented language, but seems artificial here.

Also, the coordinate system used is artificial for chess players. Maybe the JSON file deserves a rewrite to remove the `create` function and use a **right-up** orientation starting on **(1, 1)**, as explained in [this comment](https://github.com/exercism/x-common/issues/313#issuecomment-236798084).