### PR TITLE
binary-search-tree: Rewrite tests to use hspec with fail-fast.

### DIFF
--- a/exercises/binary-search-tree/package.yaml
+++ b/exercises/binary-search-tree/package.yaml
@@ -16,4 +16,4 @@ tests:
     source-dirs: test
     dependencies:
       - binary-search-tree
-      - HUnit
+      - hspec

--- a/exercises/binary-search-tree/test/Tests.hs
+++ b/exercises/binary-search-tree/test/Tests.hs
@@ -1,65 +1,78 @@
-import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), Counts(..))
-import System.Exit (ExitCode(..), exitWith)
-import BST (bstLeft, bstRight, bstValue, empty, singleton, insert, fromList, toList)
+import Test.Hspec        (Spec, describe, it, shouldBe)
+import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
 
-exitProperly :: IO Counts -> IO ()
-exitProperly m = do
-  counts <- m
-  exitWith $ if failures counts /= 0 || errors counts /= 0 then ExitFailure 1 else ExitSuccess
-
-testCase :: String -> Assertion -> Test
-testCase label assertion = TestLabel label (TestCase assertion)
+import BST
+  ( bstLeft
+  , bstRight
+  , bstValue
+  , empty
+  , fromList
+  , insert
+  , singleton
+  , toList
+  )
 
 main :: IO ()
-main = exitProperly $ runTestTT $ TestList
-       [ TestList bstTests ]
+main = hspecWith defaultConfig {configFastFail = True} specs
 
-int4 :: Int
-int4 = 4
+specs :: Spec
+specs = describe "binary-seach-tree" $ do
 
-noInts :: [Int]
-noInts = []
+    -- As of 2016-08-03, there was no reference file
+    -- for the test cases in `exercism/x-common`.
 
-bstTests :: [Test]
-bstTests =
-  [ testCase "data is retained" $
-    Just 4 @=? bstValue (singleton int4)
-  , testCase "inserting less" $ do
-    let t = insert 2 (singleton int4)
-    Just 4 @=? bstValue t
-    Just 2 @=? (bstLeft t >>= bstValue)
-  , testCase "inserting same" $ do
-    let t = insert 4 (singleton int4)
-    Just 4 @=? bstValue t
-    Just 4 @=? (bstLeft t >>= bstValue)
-  , testCase "inserting right" $ do
-    let t = insert 5 (singleton int4)
-    Just 4 @=? bstValue t
-    Just 5 @=? (bstRight t >>= bstValue)
-  , testCase "empty list to tree" $
-    empty @=? fromList noInts
-  , testCase "empty list has no value" $
-    Nothing @=? bstValue (fromList noInts)
-  , testCase "inserting into empty" $ do
-    let t = insert int4 empty
-    Just 4 @=? bstValue t
-  , testCase "complex tree" $ do
-    let t = fromList [int4, 2, 6, 1, 3, 7, 5]
-    Just 4 @=? bstValue t
-    Just 2 @=? (bstLeft t >>= bstValue)
-    Just 1 @=? (bstLeft t >>= bstLeft >>= bstValue)
-    Just 3 @=? (bstLeft t >>= bstRight >>= bstValue)
-    Just 6 @=? (bstRight t >>= bstValue)
-    Just 5 @=? (bstRight t >>= bstLeft >>= bstValue)
-    Just 7 @=? (bstRight t >>= bstRight >>= bstValue)
-  , testCase "empty tree to list" $
-    0 @=? length (toList empty)
-  , testCase "iterating one element" $
-    [4] @=? toList (singleton int4)
-  , testCase "iterating over smaller element" $
-    [2, 4] @=? toList (fromList [int4, 2])
-  , testCase "iterating over larger element" $
-    [4, 5] @=? toList (fromList [int4, 5])
-  , testCase "iterating over complex tree" $
-    [1..7] @=? toList (fromList [int4, 2, 1, 3, 6, 7, 5])
-  ]
+    let int4   = 4  ::  Int
+    let noInts = [] :: [Int]
+
+    it "data is retained" $
+      bstValue (singleton int4) `shouldBe` Just 4
+
+    it "inserting less" $ do
+      let t = insert 2 (singleton int4)
+      bstValue t `shouldBe` Just 4
+      (bstLeft t >>= bstValue) `shouldBe` Just 2
+
+    it "inserting same" $ do
+      let t = insert 4 (singleton int4)
+      bstValue t `shouldBe` Just 4
+      (bstLeft t >>= bstValue) `shouldBe` Just 4
+
+    it "inserting right" $ do
+      let t = insert 5 (singleton int4)
+      bstValue t `shouldBe` Just 4
+      (bstRight t >>= bstValue) `shouldBe` Just 5
+
+    it "empty list to tree" $
+      fromList noInts `shouldBe` empty
+
+    it "empty list has no value" $
+      bstValue (fromList noInts) `shouldBe` Nothing
+
+    it "inserting into empty" $ do
+      let t = insert int4 empty
+      bstValue t `shouldBe` Just 4
+
+    it "complex tree" $ do
+      let t = fromList [int4, 2, 6, 1, 3, 7, 5]
+      (bstValue t                          ) `shouldBe` Just 4
+      (bstLeft  t >>= bstValue             ) `shouldBe` Just 2
+      (bstLeft  t >>= bstLeft  >>= bstValue) `shouldBe` Just 1
+      (bstLeft  t >>= bstRight >>= bstValue) `shouldBe` Just 3
+      (bstRight t >>= bstValue             ) `shouldBe` Just 6
+      (bstRight t >>= bstLeft  >>= bstValue) `shouldBe` Just 5
+      (bstRight t >>= bstRight >>= bstValue) `shouldBe` Just 7
+
+    it "empty tree to list" $
+      length (toList empty) `shouldBe` 0
+
+    it "iterating one element" $
+      toList (singleton int4) `shouldBe` [4]
+
+    it "iterating over smaller element" $
+      toList (fromList [int4, 2]) `shouldBe` [2, 4]
+
+    it "iterating over larger element" $
+      toList (fromList [int4, 5]) `shouldBe` [4, 5]
+
+    it "iterating over complex tree" $
+      toList (fromList [int4, 2, 1, 3, 6, 7, 5]) `shouldBe` [1..7]


### PR DESCRIPTION
Related to #211.