### PR TITLE
difference-of-squares: Rewrite tests to use hspec with fail-fast.

### DIFF
--- a/exercises/difference-of-squares/package.yaml
+++ b/exercises/difference-of-squares/package.yaml
@@ -16,4 +16,4 @@ tests:
     source-dirs: test
     dependencies:
       - difference-of-squares
-      - HUnit
+      - hspec

--- a/exercises/difference-of-squares/src/Squares.hs
+++ b/exercises/difference-of-squares/src/Squares.hs
@@ -1,7 +1,10 @@
 module Squares (difference, squareOfSums, sumOfSquares) where
 
+difference :: Integral a => a -> a
 difference = undefined
 
+squareOfSums :: Integral a => a -> a
 squareOfSums = undefined
 
+sumOfSquares :: Integral a => a -> a
 sumOfSquares = undefined

--- a/exercises/difference-of-squares/test/Tests.hs
+++ b/exercises/difference-of-squares/test/Tests.hs
@@ -1,47 +1,70 @@
-import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), Counts(..))
-import System.Exit (ExitCode(..), exitWith)
-import Squares (sumOfSquares, squareOfSums, difference)
+{-# OPTIONS_GHC -fno-warn-type-defaults #-}
 
-exitProperly :: IO Counts -> IO ()
-exitProperly m = do
-  counts <- m
-  exitWith $ if failures counts /= 0 || errors counts /= 0 then ExitFailure 1 else ExitSuccess
+import Test.Hspec        (Spec, describe, it, shouldBe)
+import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
 
-testCase :: String -> Assertion -> Test
-testCase label assertion = TestLabel label (TestCase assertion)
+import Squares (difference, squareOfSums, sumOfSquares)
 
 main :: IO ()
-main = exitProperly $ runTestTT $ TestList
-       [ TestList squaresTests ]
+main = hspecWith defaultConfig {configFastFail = True} specs
 
-int :: Int -> Int
-int = id
+specs :: Spec
+specs = describe "differenceOfSquares" $ do
 
-integer :: Integer -> Integer
-integer = id
+    -- Test cases adapted from `exercism/x-common/difference-of-squares.json`
+    -- on 2016-08-03.
 
--- To add a little extra challenge, these functions should work with any
--- instance of the Integral typeclass.
-squaresTests :: [Test]
-squaresTests =
-  [ testCase "square of sums to 5" $
-    int 225 @=? squareOfSums 5
-  , testCase "sum of squares to 5" $
-    int 55 @=? sumOfSquares 5
-  , testCase "difference of sums to 5" $
-    int 170 @=? difference 5
-  , testCase "square of sums to 10" $
-    int 3025 @=? squareOfSums 10
-  , testCase "sum of squares to 10" $
-    int 385 @=? sumOfSquares 10
-  , testCase "difference of sums to 10" $
-    int 2640 @=? difference 10
-  , testCase "square of sums to 100" $
-    integer 25502500 @=? squareOfSums 100
-  , testCase "sum of squares to 100" $
-    integer 338350 @=? sumOfSquares 100
-  , testCase "difference of sums to 100 (Int)" $
-    int 25164150 @=? difference 100
-  , testCase "difference of sums to 100 (Integer)" $
-    integer 25164150 @=? difference 100
-  ]
+    describe "squareOfSums" $ do
+      it "square of sum 5"   $ squareOfSums   5 `shouldBe`      225
+      it "square of sum 10"  $ squareOfSums  10 `shouldBe`     3025
+      it "square of sum 100" $ squareOfSums 100 `shouldBe` 25502500
+
+    describe "sumOfSquares" $ do
+      it "sum of squares 5"   $ sumOfSquares   5 `shouldBe`     55
+      it "sum of squares 10"  $ sumOfSquares  10 `shouldBe`    385
+      it "sum of squares 100" $ sumOfSquares 100 `shouldBe` 338350
+
+    describe "differenceOfSquares" $ do
+      it "difference of squares 0"   $ difference   0 `shouldBe`        0
+      it "difference of squares 5"   $ difference   5 `shouldBe`      170
+      it "difference of squares 10"  $ difference  10 `shouldBe`     2640
+      it "difference of squares 100" $ difference 100 `shouldBe` 25164150
+
+    -- Track-specific tests.
+
+    describe "Integral tests" $ do
+
+      describe "squareOfSums" $ do
+
+        it "squareOfSums (6 :: Int)" $
+          squareOfSums (6 :: Int)
+          `shouldBe` (441 :: Int)
+
+        it "squareOfSums (7 :: Integer)" $
+          squareOfSums (7 :: Integer)
+          `shouldBe` (784 :: Integer)
+
+      describe "sumOfSquares" $ do
+
+        it "sumOfSquares (8 :: Int)" $
+          sumOfSquares (8 :: Int)
+          `shouldBe` (204 :: Int)
+
+        it "sumOfSquares (9 :: Integer)" $
+          sumOfSquares (9 :: Integer)
+          `shouldBe` (285 :: Integer)
+
+      describe "difference" $ do
+
+        it "difference (11 :: Int)" $
+          difference (11 :: Int)
+          `shouldBe` (3850 :: Int)
+
+        it "difference (12 :: Integer)" $
+          difference (12 :: Integer)
+          `shouldBe` (5434 :: Integer)
+
+      describe "huge difference" $
+        it "difference (1234567890 :: Integer)" $
+          difference (1234567890 :: Integer)
+          `shouldBe` (580764307309260838625720836817589660 :: Integer)


### PR DESCRIPTION
- Rewrite tests to use `hspec`.
- Update tests to match `x-common`
- Rewrite tests for an `Integral` implementation.
- Add `Integral` type signatures to stub solution.

Related to #211.
