### PR TITLE
luhn: Rewrite tests to use hspec with fail-fast.

### DIFF
--- a/exercises/luhn/package.yaml
+++ b/exercises/luhn/package.yaml
@@ -16,4 +16,4 @@ tests:
     source-dirs: test
     dependencies:
       - luhn
-      - HUnit
+      - hspec


### PR DESCRIPTION
Related to #211.