### PR TITLE
house: Rewrite tests to use hspec with fail-fast.

### DIFF
--- a/exercises/house/package.yaml
+++ b/exercises/house/package.yaml
@@ -16,4 +16,4 @@ tests:
     source-dirs: test
     dependencies:
       - house
-      - HUnit
+      - hspec

--- a/exercises/house/test/Tests.hs
+++ b/exercises/house/test/Tests.hs
@@ -1,110 +1,103 @@
-import Test.HUnit ( Test(..), (~?=), runTestTT, Counts(..) )
-import System.Exit (ExitCode(..), exitWith) 
-import House ( rhyme )
+import Test.Hspec        (Spec, describe, it, shouldBe)
+import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
 
-exitProperly :: IO Counts -> IO ()
-exitProperly m = do
-  counts <- m
-  exitWith $ if failures counts /= 0 || errors counts /= 0
-               then ExitFailure 1
-               else ExitSuccess
-
-houseTest :: Test
-houseTest = rhyme ~?= expected
+import House (rhyme)
 
 main :: IO ()
-main = exitProperly $ runTestTT houseTest
+main = hspecWith defaultConfig {configFastFail = True} specs
 
-expected :: String
-expected = unlines [
-    "This is the house that Jack built."
-  , ""
-  , "This is the malt"
-  , "that lay in the house that Jack built."
-  , ""
-  , "This is the rat"
-  , "that ate the malt"
-  , "that lay in the house that Jack built."
-  , ""
-  , "This is the cat"
-  , "that killed the rat"
-  , "that ate the malt"
-  , "that lay in the house that Jack built."
-  , ""
-  , "This is the dog"
-  , "that worried the cat"
-  , "that killed the rat"
-  , "that ate the malt"
-  , "that lay in the house that Jack built."
-  , ""
-  , "This is the cow with the crumpled horn"
-  , "that tossed the dog" 
-  , "that worried the cat"
-  , "that killed the rat"
-  , "that ate the malt"
-  , "that lay in the house that Jack built."
-  , ""
-  , "This is the maiden all forlorn"
-  , "that milked the cow with the crumpled horn"
-  , "that tossed the dog"
-  , "that worried the cat"
-  , "that killed the rat"
-  , "that ate the malt"
-  , "that lay in the house that Jack built."
-  , ""
-  , "This is the man all tattered and torn"
-  , "that kissed the maiden all forlorn"
-  , "that milked the cow with the crumpled horn"
-  , "that tossed the dog"
-  , "that worried the cat"
-  , "that killed the rat"
-  , "that ate the malt"
-  , "that lay in the house that Jack built."
-  , ""
-  , "This is the priest all shaven and shorn"
-  , "that married the man all tattered and torn"
-  , "that kissed the maiden all forlorn"
-  , "that milked the cow with the crumpled horn"
-  , "that tossed the dog"
-  , "that worried the cat"
-  , "that killed the rat"
-  , "that ate the malt"
-  , "that lay in the house that Jack built."
-  , ""
-  , "This is the rooster that crowed in the morn"
-  , "that woke the priest all shaven and shorn"
-  , "that married the man all tattered and torn"
-  , "that kissed the maiden all forlorn"
-  , "that milked the cow with the crumpled horn"
-  , "that tossed the dog"
-  , "that worried the cat"
-  , "that killed the rat"
-  , "that ate the malt"
-  , "that lay in the house that Jack built."
-  , ""
-  , "This is the farmer sowing his corn"
-  , "that kept the rooster that crowed in the morn"
-  , "that woke the priest all shaven and shorn"
-  , "that married the man all tattered and torn"
-  , "that kissed the maiden all forlorn"
-  , "that milked the cow with the crumpled horn"
-  , "that tossed the dog"
-  , "that worried the cat"
-  , "that killed the rat"
-  , "that ate the malt"
-  , "that lay in the house that Jack built."
-  , ""
-  , "This is the horse and the hound and the horn"
-  , "that belonged to the farmer sowing his corn"
-  , "that kept the rooster that crowed in the morn"
-  , "that woke the priest all shaven and shorn"
-  , "that married the man all tattered and torn"
-  , "that kissed the maiden all forlorn"
-  , "that milked the cow with the crumpled horn"
-  , "that tossed the dog"
-  , "that worried the cat"
-  , "that killed the rat"
-  , "that ate the malt"
-  , "that lay in the house that Jack built."
-  , ""
-  ]
+specs :: Spec
+specs = describe "house" $
+          it "rhyme" $ rhyme `shouldBe` expected
+  where
+    expected = "This is the house that Jack built.\n\
+               \\n\
+               \This is the malt\n\
+               \that lay in the house that Jack built.\n\
+               \\n\
+               \This is the rat\n\
+               \that ate the malt\n\
+               \that lay in the house that Jack built.\n\
+               \\n\
+               \This is the cat\n\
+               \that killed the rat\n\
+               \that ate the malt\n\
+               \that lay in the house that Jack built.\n\
+               \\n\
+               \This is the dog\n\
+               \that worried the cat\n\
+               \that killed the rat\n\
+               \that ate the malt\n\
+               \that lay in the house that Jack built.\n\
+               \\n\
+               \This is the cow with the crumpled horn\n\
+               \that tossed the dog\n\
+               \that worried the cat\n\
+               \that killed the rat\n\
+               \that ate the malt\n\
+               \that lay in the house that Jack built.\n\
+               \\n\
+               \This is the maiden all forlorn\n\
+               \that milked the cow with the crumpled horn\n\
+               \that tossed the dog\n\
+               \that worried the cat\n\
+               \that killed the rat\n\
+               \that ate the malt\n\
+               \that lay in the house that Jack built.\n\
+               \\n\
+               \This is the man all tattered and torn\n\
+               \that kissed the maiden all forlorn\n\
+               \that milked the cow with the crumpled horn\n\
+               \that tossed the dog\n\
+               \that worried the cat\n\
+               \that killed the rat\n\
+               \that ate the malt\n\
+               \that lay in the house that Jack built.\n\
+               \\n\
+               \This is the priest all shaven and shorn\n\
+               \that married the man all tattered and torn\n\
+               \that kissed the maiden all forlorn\n\
+               \that milked the cow with the crumpled horn\n\
+               \that tossed the dog\n\
+               \that worried the cat\n\
+               \that killed the rat\n\
+               \that ate the malt\n\
+               \that lay in the house that Jack built.\n\
+               \\n\
+               \This is the rooster that crowed in the morn\n\
+               \that woke the priest all shaven and shorn\n\
+               \that married the man all tattered and torn\n\
+               \that kissed the maiden all forlorn\n\
+               \that milked the cow with the crumpled horn\n\
+               \that tossed the dog\n\
+               \that worried the cat\n\
+               \that killed the rat\n\
+               \that ate the malt\n\
+               \that lay in the house that Jack built.\n\
+               \\n\
+               \This is the farmer sowing his corn\n\
+               \that kept the rooster that crowed in the morn\n\
+               \that woke the priest all shaven and shorn\n\
+               \that married the man all tattered and torn\n\
+               \that kissed the maiden all forlorn\n\
+               \that milked the cow with the crumpled horn\n\
+               \that tossed the dog\n\
+               \that worried the cat\n\
+               \that killed the rat\n\
+               \that ate the malt\n\
+               \that lay in the house that Jack built.\n\
+               \\n\
+               \This is the horse and the hound and the horn\n\
+               \that belonged to the farmer sowing his corn\n\
+               \that kept the rooster that crowed in the morn\n\
+               \that woke the priest all shaven and shorn\n\
+               \that married the man all tattered and torn\n\
+               \that kissed the maiden all forlorn\n\
+               \that milked the cow with the crumpled horn\n\
+               \that tossed the dog\n\
+               \that worried the cat\n\
+               \that killed the rat\n\
+               \that ate the malt\n\
+               \that lay in the house that Jack built.\n\
+               \\n\
+               \"


### PR DESCRIPTION
- Rewrite tests to use `hspec`.
- Remove use of `unlines`.

Considering that this exercise is about refactoring, the test suite should contain the most crude representation of the song, so we avoid `unlines` to let the user figure that out.

Related to #211.
