### PR TITLE
minesweeper: Rewrite tests to use hspec with fail-fast.

### DIFF
--- a/exercises/minesweeper/package.yaml
+++ b/exercises/minesweeper/package.yaml
@@ -17,4 +17,4 @@ tests:
     source-dirs: test
     dependencies:
       - minesweeper
-      - HUnit
+      - hspec


### PR DESCRIPTION
Related to #211.