### PR TITLE
ocr-numbers: Rewrite tests to use hspec with fail-fast.

### DIFF
--- a/exercises/ocr-numbers/package.yaml
+++ b/exercises/ocr-numbers/package.yaml
@@ -18,4 +18,4 @@ tests:
     source-dirs: test
     dependencies:
       - ocr-numbers
-      - HUnit
+      - hspec


### PR DESCRIPTION
Related to #211.