### PR TITLE
trinary: Rewrite tests to use hspec with fail-fast.

### DIFF
--- a/exercises/trinary/package.yaml
+++ b/exercises/trinary/package.yaml
@@ -16,4 +16,5 @@ tests:
     source-dirs: test
     dependencies:
       - trinary
+      - hspec
       - QuickCheck


### PR DESCRIPTION
Related to #211.
