### PR TITLE
food-chain: Rewrite tests to use hspec with fail-fast.

### DIFF
--- a/exercises/food-chain/package.yaml
+++ b/exercises/food-chain/package.yaml
@@ -17,4 +17,4 @@ tests:
     source-dirs: test
     dependencies:
       - food-chain
-      - HUnit
+      - hspec

--- a/exercises/food-chain/test/Tests.hs
+++ b/exercises/food-chain/test/Tests.hs
@@ -1,71 +1,63 @@
-import Test.HUnit (Test(..), (~?=), runTestTT, Counts(..))
-import System.Exit (ExitCode(..), exitWith) 
+import Test.Hspec        (Spec, describe, it, shouldBe)
+import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+
 import FoodChain (song)
 
-exitProperly :: IO Counts -> IO ()
-exitProperly m = do
-  counts <- m
-  exitWith $ if failures counts /= 0 || errors counts /= 0
-               then ExitFailure 1
-               else ExitSuccess
-
-foodChainTest :: Test
-foodChainTest = song ~?= expected
-
 main :: IO ()
-main = exitProperly $ runTestTT foodChainTest
+main = hspecWith defaultConfig {configFastFail = True} specs
 
-expected :: String
-expected = unlines [
-    "I know an old lady who swallowed a fly."
-  , "I don't know why she swallowed the fly. Perhaps she'll die."
-  , ""
-  , "I know an old lady who swallowed a spider."
-  , "It wriggled and jiggled and tickled inside her."
-  , "She swallowed the spider to catch the fly."
-  , "I don't know why she swallowed the fly. Perhaps she'll die."
-  , ""
-  , "I know an old lady who swallowed a bird."
-  , "How absurd to swallow a bird!"
-  , "She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her."
-  , "She swallowed the spider to catch the fly."
-  , "I don't know why she swallowed the fly. Perhaps she'll die."
-  , ""
-  , "I know an old lady who swallowed a cat."
-  , "Imagine that, to swallow a cat!"
-  , "She swallowed the cat to catch the bird."
-  , "She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her."
-  , "She swallowed the spider to catch the fly."
-  , "I don't know why she swallowed the fly. Perhaps she'll die."
-  , ""
-  , "I know an old lady who swallowed a dog."
-  , "What a hog, to swallow a dog!"
-  , "She swallowed the dog to catch the cat."
-  , "She swallowed the cat to catch the bird."
-  , "She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her."
-  , "She swallowed the spider to catch the fly."
-  , "I don't know why she swallowed the fly. Perhaps she'll die."
-  , ""
-  , "I know an old lady who swallowed a goat."
-  , "Just opened her throat and swallowed a goat!"
-  , "She swallowed the goat to catch the dog."
-  , "She swallowed the dog to catch the cat."
-  , "She swallowed the cat to catch the bird."
-  , "She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her."
-  , "She swallowed the spider to catch the fly."
-  , "I don't know why she swallowed the fly. Perhaps she'll die."
-  , ""
-  , "I know an old lady who swallowed a cow."
-  , "I don't know how she swallowed a cow!"
-  , "She swallowed the cow to catch the goat."
-  , "She swallowed the goat to catch the dog."
-  , "She swallowed the dog to catch the cat."
-  , "She swallowed the cat to catch the bird."
-  , "She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her."
-  , "She swallowed the spider to catch the fly."
-  , "I don't know why she swallowed the fly. Perhaps she'll die."
-  , ""
-  , "I know an old lady who swallowed a horse."
-  , "She's dead, of course!"
-  , ""
-  ]
+specs :: Spec
+specs = describe "food-chain" $
+          it "song" $ song `shouldBe` expected
+  where
+    expected = "I know an old lady who swallowed a fly.\n\
+               \I don't know why she swallowed the fly. Perhaps she'll die.\n\
+               \\n\
+               \I know an old lady who swallowed a spider.\n\
+               \It wriggled and jiggled and tickled inside her.\n\
+               \She swallowed the spider to catch the fly.\n\
+               \I don't know why she swallowed the fly. Perhaps she'll die.\n\
+               \\n\
+               \I know an old lady who swallowed a bird.\n\
+               \How absurd to swallow a bird!\n\
+               \She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.\n\
+               \She swallowed the spider to catch the fly.\n\
+               \I don't know why she swallowed the fly. Perhaps she'll die.\n\
+               \\n\
+               \I know an old lady who swallowed a cat.\n\
+               \Imagine that, to swallow a cat!\n\
+               \She swallowed the cat to catch the bird.\n\
+               \She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.\n\
+               \She swallowed the spider to catch the fly.\n\
+               \I don't know why she swallowed the fly. Perhaps she'll die.\n\
+               \\n\
+               \I know an old lady who swallowed a dog.\n\
+               \What a hog, to swallow a dog!\n\
+               \She swallowed the dog to catch the cat.\n\
+               \She swallowed the cat to catch the bird.\n\
+               \She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.\n\
+               \She swallowed the spider to catch the fly.\n\
+               \I don't know why she swallowed the fly. Perhaps she'll die.\n\
+               \\n\
+               \I know an old lady who swallowed a goat.\n\
+               \Just opened her throat and swallowed a goat!\n\
+               \She swallowed the goat to catch the dog.\n\
+               \She swallowed the dog to catch the cat.\n\
+               \She swallowed the cat to catch the bird.\n\
+               \She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.\n\
+               \She swallowed the spider to catch the fly.\n\
+               \I don't know why she swallowed the fly. Perhaps she'll die.\n\
+               \\n\
+               \I know an old lady who swallowed a cow.\n\
+               \I don't know how she swallowed a cow!\n\
+               \She swallowed the cow to catch the goat.\n\
+               \She swallowed the goat to catch the dog.\n\
+               \She swallowed the dog to catch the cat.\n\
+               \She swallowed the cat to catch the bird.\n\
+               \She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.\n\
+               \She swallowed the spider to catch the fly.\n\
+               \I don't know why she swallowed the fly. Perhaps she'll die.\n\
+               \\n\
+               \I know an old lady who swallowed a horse.\n\
+               \She's dead, of course!\n\
+               \\n"


### PR DESCRIPTION
- Rewrite tests to use `hspec`.
- Remove use of `unlines`.

Related to #211.

