### PR TITLE
queen-attack: switch row/column in comment

### DIFF
--- a/exercises/queen-attack/src/Queens.hs
+++ b/exercises/queen-attack/src/Queens.hs
@@ -1,9 +1,10 @@
 module Queens (boardString, canAttack) where
 
 -- Positions are specified as two-tuples.
--- The first element is is the column (file in Chess terms).
--- The second element is the row (rank in Chess terms).
--- (0, 0) is the top left of the board, and (7, 7) is the bottom right.
+-- The first element is the row (rank in Chess terms).
+-- The second element is is the column (file in Chess terms).
+-- (0, 0) is the top left of the board, (0, 7) is the upper right,
+-- (7, 0) is the bottom left, and (7, 7) is the bottom right.
 
 boardString :: Maybe (Int, Int) -> Maybe (Int, Int) -> String
 boardString white black = undefined


### PR DESCRIPTION
In #207 the comment was added, but the comment was incorrect compared to
what the test cases were testing. This commit repairs the comment to
match the tests.

All four corners of the board are specified to make this abundantly
clear.

Closes #276