### PR TITLE
travis: Drop compatibility with old Stack snapshots.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,6 @@ cache:
 env:
  - RESOLVER="nightly-2016-07-17" CURRENT="YES" # Equal to each stack.yaml.
  - RESOLVER="nightly"                          # Latest nightly snapshot.
- - RESOLVER="lts-2.22"                         # Last GHC 7.8.x snapshot.
- - RESOLVER="lts-6.7"                          # Last GHC 7.10.x snapshot.
 
 matrix:
   allow_failures:             # The snapshot `nightly` is just an aliases to


### PR DESCRIPTION
This removes integration tests for unused Stack snapshots in Travis CI. Only the current snapshot and `nightly` will be automatically tested.

Compatibility code in the test suites can now be removed safely.

Closes #264.