### PR TITLE
Minesweeper match json

### DIFF
--- a/exercises/minesweeper/package.yaml
+++ b/exercises/minesweeper/package.yaml
@@ -9,7 +9,6 @@ library:
   dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
-    - array
 
 tests:
   test:

--- a/exercises/minesweeper/src/Example.hs
+++ b/exercises/minesweeper/src/Example.hs
@@ -1,25 +1,25 @@
 module Minesweeper (annotate) where
 
-import Data.Char (intToDigit)
-import Data.Array (listArray, (!))
+import Data.Char  (intToDigit)
+import Data.Maybe (mapMaybe)
 
 annotate :: [String] -> [String]
-annotate board = [[ out (x, y) | x <- [1 .. xn]] | y <- [1 .. yn]]
+annotate xss = [[ fixTile x (i, j)
+                | (j, x ) <- zip [0..] xs  ]
+                | (i, xs) <- zip [0..] xss ]
   where
-    yn = length board
-    -- assume rectangular input
-    xn | yn > 0    = length (head board)
-       | otherwise = 0
-    out ix
-      | mines ! ix = '*'
-      | otherwise  = showMineCount . sum . neighbors $ ix
-    showMineCount 0 = ' '
-    showMineCount i = intToDigit i
-    isMine = ('*' ==)
-    mines = listArray ((1, 1), (xn, yn)) (map isMine (concat board))
-    neighbors (x, y) =
-      [ fromEnum (mines ! (x', y'))
-      | y' <- [max 1 (y - 1) .. min yn (y + 1)]
-      , x' <- [max 1 (x - 1) .. min xn (x + 1)]
-      , x' /= x || y' /= y
-      ]
+
+    bombs = length . filter (== '*') . mapMaybe (flip lookup tiles) . neighbors
+
+    fixTile ' ' position = case bombs position of
+        0 -> ' '
+        x -> intToDigit x
+    fixTile x _ = x
+
+    neighbors (i, j) = [ (i - 1, j - 1), (i - 1, j), (i - 1, j + 1)
+                       , (i    , j - 1),             (i    , j + 1)
+                       , (i + 1, j - 1), (i + 1, j), (i + 1, j + 1) ]
+
+    tiles = [ ((i, j), x)
+            | (i, xs) <- zip [0 :: Int ..] xss
+            , (j, x ) <- zip [0 :: Int ..] xs  ]

--- a/exercises/minesweeper/test/Tests.hs
+++ b/exercises/minesweeper/test/Tests.hs
@@ -12,9 +12,6 @@ specs = describe "minesweeper" $
           describe "annotate" $ for_ cases test
   where
 
-    -- As of 2016-08-09, there was no reference file
-    -- for the test cases in `exercism/x-common`.
-
     test (description, board) = it description assertion
       where
         assertion  = annotate (clearBoard board) `shouldBe` board
@@ -22,21 +19,32 @@ specs = describe "minesweeper" $
         mineOrSpace '*' = '*'
         mineOrSpace  _  = ' '
 
-    cases = [ ("zero size board" , [] )
+    -- Test cases adapted from `exercism/x-common/minesweeper.json`
+    -- on 2016-09-05.
 
-            , ("empty board" , [ "   "
-                               , "   "
-                               , "   " ] )
+    cases = [ ("no rows", [] )
 
-            , ("board full of mines" , [ "***"
-                                       , "***"
-                                       , "***" ] )
+            , ("no columns", [ "" ] )
 
-            , ("surrounded", [ "***"
-                             , "*8*"
-                             , "***" ] )
+            , ("no mines", [ "   "
+                           , "   "
+                           , "   " ] )
+
+            , ("board with only mines", [ "***"
+                                        , "***"
+                                        , "***" ] )
+
+            , ("mine surrounded by spaces", [ "111"
+                                            , "1*1"
+                                            , "111" ] )
+
+            , ("space surrounded by mines", [ "***"
+                                            , "*8*"
+                                            , "***" ] )
 
             , ("horizontal line", [ "1*2*1" ] )
+
+            , ("horizontal line, mines at edges", [ "*1 1*" ] )
 
             , ("vertical line", [ "1"
                                 , "*"
@@ -44,9 +52,22 @@ specs = describe "minesweeper" $
                                 , "*"
                                 , "1" ] )
 
+            , ("vertical line, mines at edges", [ "*"
+                                                , "1"
+                                                , " "
+                                                , "1"
+                                                , "*" ] )
+
             , ("cross", [ " 2*2 "
                         , "25*52"
                         , "*****"
                         , "25*52"
                         , " 2*2 " ] )
+
+            , ("large board", [ "1*22*1"
+                              , "12*322"
+                              , " 123*2"
+                              , "112*4*"
+                              , "1*22*2"
+                              , "111111" ] )
             ]


### PR DESCRIPTION
- Update tests to match `x-common`.
- Rewrite example solution to pass the new tests.

Closes #273.