### PR TITLE
nth-prime: Rewrite tests to use hspec with fail-fast.

### DIFF
--- a/exercises/nth-prime/package.yaml
+++ b/exercises/nth-prime/package.yaml
@@ -16,4 +16,4 @@ tests:
     source-dirs: test
     dependencies:
       - nth-prime
-      - HUnit
+      - hspec

--- a/exercises/nth-prime/src/Example.hs
+++ b/exercises/nth-prime/src/Example.hs
@@ -1,7 +1,12 @@
 module Prime (nth) where
 
-nth :: Int -> Integer
-nth = (primes !!) . pred
+nth :: Int -> Maybe Integer
+nth x
+    | x <= 0    = Nothing
+    | otherwise = Just $ nth' x
+
+nth' :: Int -> Integer
+nth' = (primes !!) . pred
 
 -- all primes > 5 are in the form of 6n+1 or 6n+5 (for n >= 1)
 primes :: [Integer]

--- a/exercises/nth-prime/test/Tests.hs
+++ b/exercises/nth-prime/test/Tests.hs
@@ -1,24 +1,52 @@
-import Test.HUnit ((@=?), runTestTT, Test(..), Counts(..))
-import System.Exit (ExitCode(..), exitWith)
+{-# OPTIONS_GHC -fno-warn-type-defaults #-}
+{-# LANGUAGE RecordWildCards #-}
+
+import Data.Foldable     (for_)
+import Test.Hspec        (Spec, describe, it, shouldBe)
+import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+
 import Prime (nth)
 
-exitProperly :: IO Counts -> IO ()
-exitProperly m = do
-  counts <- m
-  exitWith $ if failures counts /= 0 || errors counts /= 0 then ExitFailure 1 else ExitSuccess
-
 main :: IO ()
-main = exitProperly $ runTestTT $ TestList
-       [ TestList primeTests ]
+main = hspecWith defaultConfig {configFastFail = True} specs
 
-primeTests :: [Test]
-primeTests = map TestCase
-  [ 2 @=? nth 1
-  , 3 @=? nth 2
-  , 13 @=? nth 6
-  , [2,3,5,7,11,13,17,19,23,29,31,37,41,43,47,53,59,61,67,71] @=?
-    map nth [1..20]
-  , 7919 @=? nth 1000
-  , 104729 @=? nth 10000
-  , 104743 @=? nth 10001
-  ]
+specs :: Spec
+specs = describe "nth-prime" $
+          describe "nth" $ for_ cases test
+  where
+
+    test Case{..} = it description assertion
+      where
+        assertion = nth (fromIntegral input) `shouldBe` expected
+
+-- As of 2016-09-06, there was no reference file for the test cases in
+-- `exercism/x-common`, so we adapted the test cases available in the
+-- pull request `exercism/x-common#332`.
+
+data Case = Case { description :: String
+                 , input       :: Integer
+                 , expected    :: Maybe Integer
+                 }
+
+cases :: [Case]
+cases = [ Case { description = "first prime"
+               , input       = 1
+               , expected    = Just 2
+               }
+        , Case { description = "second prime"
+               , input       = 2
+               , expected    = Just 3
+               }
+        , Case { description = "sixth prime"
+               , input       = 6
+               , expected    = Just 13
+               }
+        , Case { description = "big prime"
+               , input       = 10001
+               , expected    = Just 104743
+               }
+        , Case { description = "there is no zeroth prime"
+               , input       = 0
+               , expected    = Nothing
+               }
+        ]


### PR DESCRIPTION
- Rewrite tests to use hspec.
- Update tests to match exercism/x-common#332.
- Change return type to Maybe.

Related to #211.
