### PR TITLE
pig-latin: Rewrite tests to use hspec with fail-fast.

### DIFF
--- a/exercises/pig-latin/package.yaml
+++ b/exercises/pig-latin/package.yaml
@@ -16,4 +16,4 @@ tests:
     source-dirs: test
     dependencies:
       - pig-latin
-      - HUnit
+      - hspec

--- a/exercises/pig-latin/src/Example.hs
+++ b/exercises/pig-latin/src/Example.hs
@@ -8,6 +8,8 @@ consonantCluster = qu . break (`elem` "aeiou")
         qu pair = pair
 
 translateWord :: String -> String
+translateWord xs@('y':'t':_) = xs ++ "ay" -- I'm not proud of this ugly hack,
+translateWord xs@('x':'r':_) = xs ++ "ay" -- but now it passes the tests.
 translateWord w0 = concat [before, w, cs, "ay", after]
   where
     (before, w1) = break isLetter w0

--- a/exercises/pig-latin/test/Tests.hs
+++ b/exercises/pig-latin/test/Tests.hs
@@ -1,36 +1,42 @@
-import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), Counts(..))
-import System.Exit (ExitCode(..), exitWith)
+import Test.Hspec        (Spec, describe, it, shouldBe)
+import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+
 import PigLatin (translate)
 
-exitProperly :: IO Counts -> IO ()
-exitProperly m = do
-  counts <- m
-  exitWith $ if failures counts /= 0 || errors counts /= 0 then ExitFailure 1 else ExitSuccess
-
-testCase :: String -> Assertion -> Test
-testCase label assertion = TestLabel label (TestCase assertion)
-
 main :: IO ()
-main = exitProperly $ runTestTT $ TestList
-       [ TestList pigLatinTests ]
+main = hspecWith defaultConfig {configFastFail = True} specs
 
-pigLatinTests :: [Test]
-pigLatinTests =
-  [ testCase "beginning with vowels" $ do
-    "appleay" @=? translate "apple"
-    "earay" @=? translate "ear"
-  , testCase "beginning with single letter consonant clusters" $ do
-    "igpay" @=? translate "pig"
-    "oalakay" @=? translate "koala"
-    "atqay"   @=? translate "qat"
-  , testCase "beginning with multiple letter consonant clusters" $ do
-    "airchay" @=? translate "chair"
-    "erapythay" @=? translate "therapy"
-    "ushthray" @=? translate "thrush"
-    "oolschay" @=? translate "school"
-  , testCase "consonant clusters with qu" $ do
-    "eenquay" @=? translate "queen"
-    "aresquay" @=? translate "square"
-  , testCase "phrase" $
-    "ickquay astfay unray" @=? translate "quick fast run"
-  ]
+specs :: Spec
+specs = describe "pig-latin" $
+          describe "translate" $ do
+
+    -- Test cases adapted from `exercism/x-common/pig-latin.json` on 2016-09-08.
+
+    describe "ay is added to words that start with vowels" $ do
+        it "word beginning with a" $ translate "apple"  `shouldBe` "appleay"
+        it "word beginning with e" $ translate "ear"    `shouldBe` "earay"
+        it "word beginning with i" $ translate "igloo"  `shouldBe` "iglooay"
+        it "word beginning with o" $ translate "object" `shouldBe` "objectay"
+        it "word beginning with u" $ translate "under"  `shouldBe` "underay"
+
+    describe "first letter and ay are moved to the end of words that start with consonants" $ do
+        it "word beginning with p" $ translate "pig"    `shouldBe` "igpay"
+        it "word beginning with k" $ translate "koala"  `shouldBe` "oalakay"
+        it "word beginning with y" $ translate "yellow" `shouldBe` "ellowyay"
+        it "word beginning with x" $ translate "xenon"  `shouldBe` "enonxay"
+        it "word beginning with q without a following u" $ translate "qat" `shouldBe` "atqay"
+
+    describe "some letter clusters are treated like a single consonant" $ do
+        it "word beginning with ch"  $ translate "chair"   `shouldBe` "airchay"
+        it "word beginning with qu"  $ translate "queen"   `shouldBe` "eenquay"
+        it "word beginning with qu and a preceding consonant" $ translate "square" `shouldBe` "aresquay"
+        it "word beginning with th"  $ translate "therapy" `shouldBe` "erapythay"
+        it "word beginning with thr" $ translate "thrush"  `shouldBe` "ushthray"
+        it "word beginning with sch" $ translate "school"  `shouldBe` "oolschay"
+
+    describe "some letter clusters are treated like a single vowel" $ do
+        it "word beginning with yt" $ translate "yttria" `shouldBe` "yttriaay"
+        it "word beginning with xr" $ translate "xray"   `shouldBe` "xrayay"
+
+    describe "phrases are translated" $ do
+        it "a whole phrase" $ translate "quick fast run" `shouldBe` "ickquay astfay unray"


### PR DESCRIPTION
- Rewrite test to use `hspec`.
- Update the tests to match `x-common`.
- Patch the example solution to pass the new tests.