### PR TITLE
pythagorean-triplets: Rewrite tests to use hspec with fail-fast.

### DIFF
--- a/exercises/pythagorean-triplet/package.yaml
+++ b/exercises/pythagorean-triplet/package.yaml
@@ -16,4 +16,4 @@ tests:
     source-dirs: test
     dependencies:
       - pythagorean-triplet
-      - HUnit
+      - hspec

--- a/exercises/pythagorean-triplet/test/Tests.hs
+++ b/exercises/pythagorean-triplet/test/Tests.hs
@@ -1,32 +1,44 @@
-import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), Counts(..))
-import System.Exit (ExitCode(..), exitWith)
-import Triplet (mkTriplet, isPythagorean, pythagoreanTriplets)
+{-# OPTIONS_GHC -fno-warn-type-defaults #-}
 
-exitProperly :: IO Counts -> IO ()
-exitProperly m = do
-  counts <- m
-  exitWith $ if failures counts /= 0 || errors counts /= 0 then ExitFailure 1 else ExitSuccess
+import Data.Foldable     (for_)
+import Test.Hspec        (Spec, describe, it, shouldBe)
+import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
 
-testCase :: String -> Assertion -> Test
-testCase label assertion = TestLabel label (TestCase assertion)
+import Triplet (isPythagorean, mkTriplet, pythagoreanTriplets)
 
 main :: IO ()
-main = exitProperly $ runTestTT $ TestList
-       [ TestList tripletTests ]
+main = hspecWith defaultConfig {configFastFail = True} specs
 
-tripletTests :: [Test]
-tripletTests =
-  [ testCase "isPythagorean" $ do
-    True @=? isPythagorean (mkTriplet 3 4 5)
-    True @=? isPythagorean (mkTriplet 3 5 4)
-    True @=? isPythagorean (mkTriplet 4 3 5)
-    True @=? isPythagorean (mkTriplet 4 5 3)
-    True @=? isPythagorean (mkTriplet 5 3 4)
-    True @=? isPythagorean (mkTriplet 5 4 3)
-    False @=? isPythagorean (mkTriplet 3 3 3)
-    False @=? isPythagorean (mkTriplet 5 6 7)
-  , testCase "pythagoreanTriplets" $ do
-    [mkTriplet 3 4 5, mkTriplet 6 8 10] @=? pythagoreanTriplets 1 10
-    [mkTriplet 12 16 20] @=? pythagoreanTriplets 11 20
-    [mkTriplet 57 76 95, mkTriplet 60 63 87] @=? pythagoreanTriplets 56 95
-  ]
+specs :: Spec
+specs = describe "pythagorean-triplet" $ do
+          describe "isPythagorean"       $ for_ isPythagoreanCases       isPythagoreanTest
+          describe "pythagoreanTriplets" $ for_ pythagoreanTripletsCases pythagoreanTripletsTest
+  where
+
+    isPythagoreanTest ((a, b, c), expected) = it description assertion
+      where
+        description = unwords $ show <$> [a, b, c]
+        assertion   = isPythagorean (mkTriplet a b c) `shouldBe` expected
+
+    pythagoreanTripletsTest (x, y, ts) = it description assertion
+      where
+        description = unwords $ show <$> [x, y]
+        assertion   = pythagoreanTriplets x y `shouldBe` uncurry3 mkTriplet <$> ts
+
+    uncurry3 f (x, y, z) = f x y z
+
+    -- As of 2016-09-12, there was no reference file
+    -- for the test cases in `exercism/x-common`.
+
+    isPythagoreanCases = [ ( (3, 4, 5), True )
+                         , ( (3, 5, 4), True )
+                         , ( (4, 3, 5), True )
+                         , ( (4, 5, 3), True )
+                         , ( (5, 3, 4), True )
+                         , ( (5, 4, 3), True )
+                         , ( (3, 3, 3), False)
+                         , ( (5, 6, 7), False) ]
+
+    pythagoreanTripletsCases = [ (1 , 10, [ ( 3,  4,  5), ( 6,  8, 10) ])
+                               , (11, 20, [ (12, 16, 20)               ])
+                               , (56, 95, [ (57, 76, 95), (60, 63, 87) ]) ]


### PR DESCRIPTION
Related to #211.
