### PR TITLE
simple-cipher: Rewrite tests to use hspec with fail-fast.

### DIFF
--- a/exercises/simple-cipher/package.yaml
+++ b/exercises/simple-cipher/package.yaml
@@ -17,4 +17,4 @@ tests:
     source-dirs: test
     dependencies:
       - simple-cipher
-      - HUnit
+      - hspec


### PR DESCRIPTION
This is supposed to be an almost literal translation from `HUnit` to `hspec`.

Related to #211.

