### PR TITLE
move icon attribution from exercism.io/ATTRIBUTION.md to here

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,6 @@ If the stub solution is still in the `/src` folder, build will probably fail.
 The MIT License (MIT)
 
 Copyright (c) 2014 Katrina Owen, _@kytrinyx.com
+
+### Haskell icon
+The Haskell icon was designed by Darrin Thompson and Jeff Wheeler. It was released under the [HaskellWiki license](https://wiki.haskell.org/HaskellWiki:Copyrights).


### PR DESCRIPTION
a step in fixing https://github.com/exercism/exercism.io/issues/3112.