### PR TITLE
food-chain: Rewrite tests and add working stub solution.

### DIFF
--- a/exercises/food-chain/HINTS.md
+++ b/exercises/food-chain/HINTS.md
@@ -1,0 +1,19 @@
+## Hints
+
+This exercise is about [code refactoring](https://en.wikipedia.org/wiki/Refactoring),
+so we are providing you with a solution that already passes the tests.
+
+The challenge is to rewrite it until you are proud of it, and learn
+something in the process.
+
+If you don't know where to start, here are some ideas:
+
+- Try to reduce repetition to a minimum.
+- Try to make the code readable.
+- Generalize your solution, allowing the lady to swallow other things.
+
+Take your time.
+
+Change one thing at a time and check if your solution still passes the tests.
+
+Have fun!

--- a/exercises/food-chain/src/Example.hs
+++ b/exercises/food-chain/src/Example.hs
@@ -15,7 +15,7 @@ animalNames = listArray (Fly, Horse) $ map showLower [Fly ..]
                       in (toLower h : t)
 
 song :: String
-song = unlines $ map verse [Fly ..]
+song = init . unlines $ map verse [Fly ..]
 
 verse :: Animal -> String
 verse animal = swallow animal ++ unlines (map catches prey)

--- a/exercises/food-chain/src/FoodChain.hs
+++ b/exercises/food-chain/src/FoodChain.hs
@@ -1,4 +1,54 @@
 module FoodChain (song) where
 
 song :: String
-song = undefined
+song =
+    "I know an old lady who swallowed a fly.\n\
+    \I don't know why she swallowed the fly. Perhaps she'll die.\n\
+    \\n\
+    \I know an old lady who swallowed a spider.\n\
+    \It wriggled and jiggled and tickled inside her.\n\
+    \She swallowed the spider to catch the fly.\n\
+    \I don't know why she swallowed the fly. Perhaps she'll die.\n\
+    \\n\
+    \I know an old lady who swallowed a bird.\n\
+    \How absurd to swallow a bird!\n\
+    \She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.\n\
+    \She swallowed the spider to catch the fly.\n\
+    \I don't know why she swallowed the fly. Perhaps she'll die.\n\
+    \\n\
+    \I know an old lady who swallowed a cat.\n\
+    \Imagine that, to swallow a cat!\n\
+    \She swallowed the cat to catch the bird.\n\
+    \She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.\n\
+    \She swallowed the spider to catch the fly.\n\
+    \I don't know why she swallowed the fly. Perhaps she'll die.\n\
+    \\n\
+    \I know an old lady who swallowed a dog.\n\
+    \What a hog, to swallow a dog!\n\
+    \She swallowed the dog to catch the cat.\n\
+    \She swallowed the cat to catch the bird.\n\
+    \She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.\n\
+    \She swallowed the spider to catch the fly.\n\
+    \I don't know why she swallowed the fly. Perhaps she'll die.\n\
+    \\n\
+    \I know an old lady who swallowed a goat.\n\
+    \Just opened her throat and swallowed a goat!\n\
+    \She swallowed the goat to catch the dog.\n\
+    \She swallowed the dog to catch the cat.\n\
+    \She swallowed the cat to catch the bird.\n\
+    \She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.\n\
+    \She swallowed the spider to catch the fly.\n\
+    \I don't know why she swallowed the fly. Perhaps she'll die.\n\
+    \\n\
+    \I know an old lady who swallowed a cow.\n\
+    \I don't know how she swallowed a cow!\n\
+    \She swallowed the cow to catch the goat.\n\
+    \She swallowed the goat to catch the dog.\n\
+    \She swallowed the dog to catch the cat.\n\
+    \She swallowed the cat to catch the bird.\n\
+    \She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.\n\
+    \She swallowed the spider to catch the fly.\n\
+    \I don't know why she swallowed the fly. Perhaps she'll die.\n\
+    \\n\
+    \I know an old lady who swallowed a horse.\n\
+    \She's dead, of course!\n"

--- a/exercises/food-chain/test/Tests.hs
+++ b/exercises/food-chain/test/Tests.hs
@@ -1,3 +1,4 @@
+import Data.Function     (on)
 import Test.Hspec        (Spec, describe, it, shouldBe)
 import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
 
@@ -8,56 +9,79 @@ main = hspecWith defaultConfig {configFastFail = True} specs
 
 specs :: Spec
 specs = describe "food-chain" $
-          it "song" $ song `shouldBe` expected
+
+          describe "song" $ do
+
+            -- First we test the input, line by line, to give more
+            -- useful error messages.
+
+            it "matches lines" $ sequence_ lineAssertions
+
+            -- Finally, because testing lines we are unable
+            -- to detect a missing newline at the end of the
+            -- lyrics, we test the full song.
+
+            it "matches full song" $ song `shouldBe` lyrics
   where
-    expected = "I know an old lady who swallowed a fly.\n\
-               \I don't know why she swallowed the fly. Perhaps she'll die.\n\
-               \\n\
-               \I know an old lady who swallowed a spider.\n\
-               \It wriggled and jiggled and tickled inside her.\n\
-               \She swallowed the spider to catch the fly.\n\
-               \I don't know why she swallowed the fly. Perhaps she'll die.\n\
-               \\n\
-               \I know an old lady who swallowed a bird.\n\
-               \How absurd to swallow a bird!\n\
-               \She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.\n\
-               \She swallowed the spider to catch the fly.\n\
-               \I don't know why she swallowed the fly. Perhaps she'll die.\n\
-               \\n\
-               \I know an old lady who swallowed a cat.\n\
-               \Imagine that, to swallow a cat!\n\
-               \She swallowed the cat to catch the bird.\n\
-               \She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.\n\
-               \She swallowed the spider to catch the fly.\n\
-               \I don't know why she swallowed the fly. Perhaps she'll die.\n\
-               \\n\
-               \I know an old lady who swallowed a dog.\n\
-               \What a hog, to swallow a dog!\n\
-               \She swallowed the dog to catch the cat.\n\
-               \She swallowed the cat to catch the bird.\n\
-               \She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.\n\
-               \She swallowed the spider to catch the fly.\n\
-               \I don't know why she swallowed the fly. Perhaps she'll die.\n\
-               \\n\
-               \I know an old lady who swallowed a goat.\n\
-               \Just opened her throat and swallowed a goat!\n\
-               \She swallowed the goat to catch the dog.\n\
-               \She swallowed the dog to catch the cat.\n\
-               \She swallowed the cat to catch the bird.\n\
-               \She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.\n\
-               \She swallowed the spider to catch the fly.\n\
-               \I don't know why she swallowed the fly. Perhaps she'll die.\n\
-               \\n\
-               \I know an old lady who swallowed a cow.\n\
-               \I don't know how she swallowed a cow!\n\
-               \She swallowed the cow to catch the goat.\n\
-               \She swallowed the goat to catch the dog.\n\
-               \She swallowed the dog to catch the cat.\n\
-               \She swallowed the cat to catch the bird.\n\
-               \She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.\n\
-               \She swallowed the spider to catch the fly.\n\
-               \I don't know why she swallowed the fly. Perhaps she'll die.\n\
-               \\n\
-               \I know an old lady who swallowed a horse.\n\
-               \She's dead, of course!\n\
-               \\n"
+
+    lineAssertions = (go shouldBe `on` zip [1 :: Int ..] . lines) song lyrics
+
+    go _    []     []  = []
+    go f (x:xs)    []  = f (Just x) Nothing  : go f xs []
+    go f    []  (y:ys) = f Nothing  (Just y) : go f [] ys
+    go f (x:xs) (y:ys) = f (Just x) (Just y) : go f xs ys
+
+-- Lyrics extracted from `exercism/x-common` on 2016-09-21.
+
+lyrics :: String
+lyrics =
+    "I know an old lady who swallowed a fly.\n\
+    \I don't know why she swallowed the fly. Perhaps she'll die.\n\
+    \\n\
+    \I know an old lady who swallowed a spider.\n\
+    \It wriggled and jiggled and tickled inside her.\n\
+    \She swallowed the spider to catch the fly.\n\
+    \I don't know why she swallowed the fly. Perhaps she'll die.\n\
+    \\n\
+    \I know an old lady who swallowed a bird.\n\
+    \How absurd to swallow a bird!\n\
+    \She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.\n\
+    \She swallowed the spider to catch the fly.\n\
+    \I don't know why she swallowed the fly. Perhaps she'll die.\n\
+    \\n\
+    \I know an old lady who swallowed a cat.\n\
+    \Imagine that, to swallow a cat!\n\
+    \She swallowed the cat to catch the bird.\n\
+    \She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.\n\
+    \She swallowed the spider to catch the fly.\n\
+    \I don't know why she swallowed the fly. Perhaps she'll die.\n\
+    \\n\
+    \I know an old lady who swallowed a dog.\n\
+    \What a hog, to swallow a dog!\n\
+    \She swallowed the dog to catch the cat.\n\
+    \She swallowed the cat to catch the bird.\n\
+    \She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.\n\
+    \She swallowed the spider to catch the fly.\n\
+    \I don't know why she swallowed the fly. Perhaps she'll die.\n\
+    \\n\
+    \I know an old lady who swallowed a goat.\n\
+    \Just opened her throat and swallowed a goat!\n\
+    \She swallowed the goat to catch the dog.\n\
+    \She swallowed the dog to catch the cat.\n\
+    \She swallowed the cat to catch the bird.\n\
+    \She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.\n\
+    \She swallowed the spider to catch the fly.\n\
+    \I don't know why she swallowed the fly. Perhaps she'll die.\n\
+    \\n\
+    \I know an old lady who swallowed a cow.\n\
+    \I don't know how she swallowed a cow!\n\
+    \She swallowed the cow to catch the goat.\n\
+    \She swallowed the goat to catch the dog.\n\
+    \She swallowed the dog to catch the cat.\n\
+    \She swallowed the cat to catch the bird.\n\
+    \She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.\n\
+    \She swallowed the spider to catch the fly.\n\
+    \I don't know why she swallowed the fly. Perhaps she'll die.\n\
+    \\n\
+    \I know an old lady who swallowed a horse.\n\
+    \She's dead, of course!\n"


### PR DESCRIPTION
- Use lyrics from `x-common/exercises/food-chain/canonical-data.json`.
- Tests all lines, one by one, and then the entire song.
- Add stub solution passing the tests.
- Patch example solution to work with the new tests.

This is a first try at solving #301. When we get this right, we may extend the same logic to `beer-song` and `house`.

There is some magic in the test suite to check the lyrics line by line, but I couldn't find a better way to write it.

The stub solution has the complete lyrics in the most raw form possible, so that the student will be forced to refactor everything from zero.

The previous tests suite had an empty line at the end, but that makes no sense and doesn't match the reference file.