### PR TITLE
documentation: Instructions for "No .cabal file"

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -15,6 +15,15 @@ stack test
 #### If you get an error message like this...
 
 ```
+No .cabal file found in directory
+```
+
+You are probably running an old stack version and need
+to upgrade it.
+
+#### Otherwise, if you get an error message like this...
+
+```
 No compiler found, expected minor version match with...
 Try running "stack setup" to install the correct GHC...
 ```

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -10,6 +10,15 @@ stack test
 #### If you get an error message like this...
 
 ```
+No .cabal file found in directory
+```
+
+You are probably running an old stack version and need
+to upgrade it.
+
+#### Otherwise, if you get an error message like this...
+
+```
 No compiler found, expected minor version match with...
 Try running "stack setup" to install the correct GHC...
 ```


### PR DESCRIPTION
This may be redundant, considering that we already ask for a Stack version greater than 1.1.2 in `INSTALLATION.md`, but some users try to run the tests with older versions, so it makes sense to keep this for a while.

Closes #272.