### PR TITLE
go-counting: Rewrite tests to use hspec with fail-fast.

### DIFF
--- a/exercises/go-counting/package.yaml
+++ b/exercises/go-counting/package.yaml
@@ -18,4 +18,5 @@ tests:
     source-dirs: test
     dependencies:
       - go-counting
-      - HUnit
+      - hspec
+      - multiset


### PR DESCRIPTION
- Completely rewrite tests to use `hspec`.
- Add test suite's dependency on package `multiset`.

Related to #211.

This was one of the most challenging re-writings since we started migrating the exercises to `hspec`, so I think I owe a few explanations:

- `shouldScore` is pointfree madness, but I couldn't make it more readable any other way.
- `toOccurList . fromOccurList` is the best way I could find to sum all the scores.
- `first` and `swap` are not commonly used in this repository, but I think they really make sense.

