### PR TITLE
list-ops: Improve code based on HLint's suggestions.

### DIFF
--- a/exercises/list-ops/src/Example.hs
+++ b/exercises/list-ops/src/Example.hs
@@ -28,7 +28,7 @@ length :: [a] -> Int
 length = foldl' (\acc _ -> 1 + acc) 0
 
 reverse :: [a] -> [a]
-reverse = foldl' (\acc x -> x : acc) []
+reverse = foldl' (flip (:)) []
 
 map :: (a -> b) -> [a] -> [b]
 map f = foldr (\x acc -> f x : acc) []


### PR DESCRIPTION
The following hint should be ignored, because it would create an
example solution implementing a custom `foldr` with
`Prelude.foldr`, which is against the purpose of this exercise.

```
./src/Example.hs:24:5: Suggestion: Use foldr
Found:
  go [] = x0
  go (x : xs) = x `f` go xs
Why not:
  go xs = foldr f x0 xs

1 hint
```

Related to #355.