### PR TITLE
list-ops: Ignore HLint's hint to use foldr

### DIFF
--- a/exercises/list-ops/src/Example.hs
+++ b/exercises/list-ops/src/Example.hs
@@ -18,6 +18,7 @@ foldl' f = go
     go acc [] = acc
     go acc (x:xs) = let acc' = f acc x in acc' `seq` go acc' xs
 
+{-# ANN foldr "HLint: ignore Use foldr" #-}
 foldr :: (a -> b -> b) -> b -> [a] -> b
 foldr f x0 = go
   where


### PR DESCRIPTION
As part of #355

If we are to run HLint in Travis, we'll need to tell it that it's
acceptable to not use foldr here. We don't want to use foldr since this
exercise is about implementing it!