### PR TITLE
travis: Add hlint to Travis-CI checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,13 +28,16 @@ install:
  - travis_retry fetch-configlet
  - travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 -o pack.tgz
  - tar xzf pack.tgz --wildcards --strip-components=1 -C ${HOME}/bin '*/stack'
+ - stack --resolver ${RESOLVER} --install-ghc install hlint
 
 script:
  - |
     set -e
-    configlet .
 
-    # Explicit set the resolver only if it's not the current one.
+    configlet .               # Check basic track configuration.
+    hlint ${TRAVIS_BUILD_DIR} # Run `hlint` on the entire repository.
+
+    # Explicit set exercises' resolver only if it's not the current one.
     if [ "${CURRENT}" != "YES" ]; then
         SET_RESOLVER="--resolver ${RESOLVER}"
     fi

--- a/README.md
+++ b/README.md
@@ -50,12 +50,16 @@ stack test --pedantic
 
 ### Running HLint
 
-All code in this repository should be as idiomatic as possible, so it is
-highly recommended to run `hlint` on your sources before opening a
-*pull request*.
+All code in this repository should be as idiomatic as possible, so we
+enforce in [Travis-CI] that it returns `No hints` when processed by
+HLint.
 
-Unless there is a good reason to ignore a suggestion, all submitted
-code is expected to return **No hints** when processed by it.
+It is highly recommended to run `hlint` on your sources before opening
+a *pull request*, so you can fix your code before submitting it for review.
+
+If you are certain that a suggestion given by `hlint` would make the
+code worse, you can [suppress it](https://github.com/ndmitchell/hlint#customizing-the-hints)
+with annotations in the source file.
 
 ## License
 


### PR DESCRIPTION
- Add hlint tests to the entire repository.
- Add and fix comments to match that.

Related to #355.

### Motivation

It was briefly discussed in #355 that it would be interesting to run `HLint` in Travis-CI.

Thanks to @petertseng, we discovered that `hlint` is already available and whitelisted in Travis, but the version available in Ubuntu Precise is older than the ones we would like to run.

Initial experiments showed us that, installing it from source, the initial building times could be problematic. Another problem would be to assure that we are running a known version of HLint.

I opened this PR as an experiment, to see - after we finish #355 - if it is feasible to install and run it in "production". It also serves to check if we are really done with fixing the current code base.

The general idea is to install `hlint` using the same Stack snapshot used for testing the exercises, increasing Stack cache sharing while using a HLint version known to compile without problems.

I added HLint tests between `configlet` and the exercises' test. This way we can get feedback really fast if we push something without running `hlint` before.

### Preliminary results

Installing `hlint` but not running it:

- Initial building time: **27m31s**
- Rebuilding time: **1m50s**
- Approximate cache size per snapshot: **700MB**

I had problems in my first tests, but I was not able to study the logs.
As soon as I get better Internet connection I'll go back to it.

I think we'll be able to put that in production soon @petertseng. Thanks again!