### PR TITLE
hexadecimal: Supress HLint's suggestion to use isDigit.

### DIFF
--- a/exercises/hexadecimal/src/Example.hs
+++ b/exercises/hexadecimal/src/Example.hs
@@ -1,5 +1,6 @@
 module Hexadecimal (hexToInt) where
 
+{-# ANN digitToInt "HLint: ignore Use isDigit" #-}
 digitToInt :: Char -> Maybe Int
 digitToInt c
   | c >= '0' && c <= '9' = Just $ n - fromEnum '0'


### PR DESCRIPTION
The following hint makes the function less readable:

```
./src/Example.hs:5:5: Warning: Use isDigit
Found:
  c >= '0' && c <= '9'
Why not:
  isDigit c

1 hint
```