### PR TITLE
linked-list: Supress HLint's suggestions to reduce duplication.

### DIFF
--- a/exercises/linked-list/test/Tests.hs
+++ b/exercises/linked-list/test/Tests.hs
@@ -6,6 +6,7 @@ import Deque (mkDeque, pop, push, shift, unshift)
 main :: IO ()
 main = hspecWith defaultConfig {configFastFail = True} specs
 
+{-# ANN module "HLint: ignore Reduce duplication" #-}
 specs :: Spec
 specs = describe "linked-list" $ do
 


### PR DESCRIPTION
Related to #355.

The following suggestions would probably make the tests shorter, but harder to read:

```
./test/Tests.hs:16:7: Suggestion: Reduce duplication
Found:
  deque <- mkDeque
  push deque 'a'
  push deque 'b'
Why not:
  Combine with ./test/Tests.hs:23:7

./test/Tests.hs:16:7: Suggestion: Reduce duplication
Found:
  deque <- mkDeque
  push deque 'a'
  push deque 'b'
  pop deque `shouldReturn` Just 'b'
Why not:
  Combine with ./test/Tests.hs:44:7

./test/Tests.hs:30:7: Suggestion: Reduce duplication
Found:
  deque <- mkDeque
  unshift deque 'a'
  unshift deque 'b'
Why not:
  Combine with ./test/Tests.hs:37:7

3 hints
```

It is not clear why, but `hlint` doesn't supresses the suggestions if we use `{-# ANN specs ...`, only with `{-# ANN module ...`.