### PR TITLE
bank-account: Supress HLint suggestion

### DIFF
--- a/exercises/bank-account/test/Tests.hs
+++ b/exercises/bank-account/test/Tests.hs
@@ -46,7 +46,7 @@ specs = describe "bank-account" $ do
     it "closed banks hold no balance" $ do
         account    <-    openAccount
         getBalance       account    `shouldReturn` Just  0
-        incrementBalance account 10 `shouldReturn` Just 10
+        incrementBalance account 15 `shouldReturn` Just 15
         closeAccount     account
         getBalance       account    `shouldReturn` Nothing
         incrementBalance account 10 `shouldReturn` Nothing


### PR DESCRIPTION
Related to #355.

The following suggestion would probably make the tests
shorter, but harder to read:

```
./test/Tests.hs:29:9: Suggestion: Reduce duplication
Found:
  account <- openAccount
  getBalance account `shouldReturn` Just 0
  incrementBalance account 10 `shouldReturn` Just 10
Why not:
  Combine with ./test/Tests.hs:47:9

1 hint
```

It is not clear why, but `hlint` doesn't supresses the suggestions
if we use `{-# ANN specs ...`, only with `{-# ANN module ...`.