### PR TITLE
robot-name: Fix HLint's suggestions and errors

### DIFF
--- a/exercises/robot-name/src/Example.hs
+++ b/exercises/robot-name/src/Example.hs
@@ -7,7 +7,7 @@ import System.Random (randomRIO)
 data Robot = Robot { robotNameVar :: MVar String }
 
 mkRobot :: IO Robot
-mkRobot = generateName >>= newMVar >>= return . Robot
+mkRobot = fmap Robot $ generateName >>= newMVar
 
 resetName :: Robot -> IO ()
 resetName r = void (generateName >>= swapMVar (robotNameVar r))
@@ -16,7 +16,7 @@ robotName :: Robot -> IO String
 robotName = readMVar . robotNameVar
 
 generateName :: IO String
-generateName = mapM randomRIO pattern
-  where pattern = [ letter, letter, digit, digit, digit ]
-        letter = ('A', 'Z')
-        digit = ('0', '9')
+generateName = mapM randomRIO [ letter, letter, digit, digit, digit ]
+  where
+    letter = ('A', 'Z')
+    digit  = ('0', '9')

--- a/exercises/robot-name/test/Tests.hs
+++ b/exercises/robot-name/test/Tests.hs
@@ -25,17 +25,18 @@ specs = describe "robot-name" $ do
           let d = ('0', '9')
           let matchesPattern s = length s == 5
                                  && and (zipWith inRange [a, a, d, d, d] s)
+          let testPersistence r = do
+                n1 <- robotName r
+                n2 <- robotName r
+                n3 <- robotName r
+                n1 `shouldBe` n2
+                n1 `shouldBe` n3
 
           it "name should match expected pattern" $
             mkRobot >>= robotName >>= (`shouldSatisfy` matchesPattern)
 
-          it "name is persistent" $ do
-            r <- mkRobot
-            n1 <- robotName r
-            n2 <- robotName r
-            n3 <- robotName r
-            n1 `shouldBe` n2
-            n1 `shouldBe` n3
+          it "name is persistent" $
+            mkRobot >>= testPersistence
 
           it "different robots have different names" $ do
             n1 <- mkRobot >>= robotName
@@ -49,12 +50,7 @@ specs = describe "robot-name" $ do
 
           it "new name is persistent" $ do
             r <- mkRobot
-            resetName r
-            n1 <- robotName r
-            n2 <- robotName r
-            n3 <- robotName r
-            n1 `shouldBe` n2
-            n1 `shouldBe` n3
+            resetName r >> testPersistence r
 
           it "new name is different from old name" $ do
             r <- mkRobot


### PR DESCRIPTION
Related to #355.

- Remove variable named `pattern` in `src/Example` to workaround HLint's bug that causes a parse error.

```
./src/Example.hs:19:31: Error: Parse error: pattern
Found:
    generateName :: IO String
  > generateName = mapM randomRIO pattern
      where pattern = [ letter, letter, digit, digit, digit ]
            letter = ('A', 'Z')
```

- Simplify code with `fmap`, as suggested.

```
./src/Example.hs:10:11: Suggestion: Use fmap
Found:
  generateName >>= newMVar >>= return . Robot
Why not:
  fmap Robot (generateName >>= newMVar)
```

- Supress warning to reduce code duplication that would harm readability.

```
./test/Tests.hs:34:13: Warning: Reduce duplication
Found:
  n1 <- robotName r
  n2 <- robotName r
  n3 <- robotName r
  n1 `shouldBe` n2
  n1 `shouldBe` n3
Why not:
  Combine with ./test/Tests.hs:53:13
```