### PR TITLE
hspec-lens-person: Rewrite test to use hspec with fail-fast.

### DIFF
--- a/exercises/lens-person/package.yaml
+++ b/exercises/lens-person/package.yaml
@@ -18,4 +18,4 @@ tests:
     source-dirs: test
     dependencies:
       - lens-person
-      - HUnit
+      - hspec

--- a/exercises/lens-person/src/Person.hs
+++ b/exercises/lens-person/src/Person.hs
@@ -1,39 +1,34 @@
-module Person where
+module Person
+  ( Address (..)
+  , Born    (..)
+  , Name    (..)
+  , Person  (..)
+  , bornStreet
+  , renameStreets
+  , setBirthMonth
+  , setCurrentStreet
+  ) where
 
-import           Data.Time.Calendar
+import Data.Time.Calendar (Day)
 
-data Person = Person {
-      _name    :: Name,
-      _born    :: Born,
-      _address :: Address
-    }
+data Person = Person { _name    :: Name
+                     , _born    :: Born
+                     , _address :: Address
+                     }
 
-data Name = Name {
-      _foreNames :: String, -- Space separated
-      _surName   :: String
-    }
+data Name = Name { _foreNames :: String
+                 , _surName   :: String
+                 }
 
-data Born = Born {
-      _bornAt :: Address,
-      _bornOn :: Day
-    }
+data Born = Born { _bornAt :: Address
+                 , _bornOn :: Day
+                 }
 
-data Address = Address {
-      _street      :: String,
-      _houseNumber :: Int,
-      _place       :: String, -- Village / city
-      _country     :: String
-    }
-
--- Valid values of Gregorian are those for which 'Data.Time.Calendar.fromGregorianValid'
--- returns Just.
-data Gregorian = Gregorian {
-      _year  :: Integer,
-      _month :: Int,
-      _day   :: Int
-    }
-
--- Implement these.
+data Address = Address { _street      :: String
+                       , _houseNumber :: Int
+                       , _place       :: String
+                       , _country     :: String
+                       }
 
 bornStreet :: Born -> String
 bornStreet = undefined
@@ -44,6 +39,5 @@ setCurrentStreet = undefined
 setBirthMonth :: Int -> Person -> Person
 setBirthMonth = undefined
 
--- | Transform both birth and current street names.
 renameStreets :: (String -> String) -> Person -> Person
 renameStreets = undefined


### PR DESCRIPTION
- Rewrite tests to use `hspec`.
- Remove unneeded data type `Gregorian` and rewrite stub.

Related to #211 and #302.

