### PR TITLE
rna-transcription: Remove unneeded stub comments.

### DIFF
--- a/exercises/rna-transcription/src/DNA.hs
+++ b/exercises/rna-transcription/src/DNA.hs
@@ -1,6 +1,4 @@
 module DNA (toRNA) where
 
--- | if string contains invalid character, return Nothing
--- | if string contains only valid nucleotides, return Just transcription
 toRNA :: String -> Maybe String
 toRNA = undefined


### PR DESCRIPTION
In #302, we are moving all the hints in the test suites and stub solutions to `HINTS.md` files. But the comments in `src/DNA.hs` are too obvious and may take all the fun of solving the exercise, so we are just removing them.