### PR TITLE
zipper: Rewrite tests to use hspec with fail-fast.

### DIFF
--- a/exercises/zipper/package.yaml
+++ b/exercises/zipper/package.yaml
@@ -16,4 +16,4 @@ tests:
     source-dirs: test
     dependencies:
       - zipper
-      - HUnit
+      - hspec

--- a/exercises/zipper/src/Zipper.hs
+++ b/exercises/zipper/src/Zipper.hs
@@ -1,62 +1,44 @@
-module Zipper (
-    BinTree(..),
-    Zipper,
+module Zipper
+ ( BinTree(BT)
+ , fromTree
+ , left
+ , right
+ , setLeft
+ , setRight
+ , setValue
+ , toTree
+ , up
+ , value
+ ) where
 
-    fromTree,
-    toTree,
+data BinTree a = BT { btValue :: a
+                    , btLeft  :: Maybe (BinTree a)
+                    , btRight :: Maybe (BinTree a)
+                    } deriving (Eq, Show)
 
-    value,
-    left,
-    right,
-    up,
-
-    setValue,
-    setLeft,
-    setRight
-) where
-
--- | A binary tree.
-data BinTree a = BT { 
-    btValue :: a                 -- ^ Value
-  , btLeft  :: Maybe (BinTree a) -- ^ Left child
-  , btRight :: Maybe (BinTree a) -- ^ Right child
-} deriving (Eq, Show)
-
--- | A zipper for a binary tree.
-data Zipper a -- Complete this definition
-
--- | Get a zipper focussed on the root node.
 fromTree :: BinTree a -> Zipper a
 fromTree = undefined
 
--- | Get the complete tree from a zipper.
 toTree :: Zipper a -> BinTree a
 toTree = undefined
 
--- | Get the value of the focus node.
 value :: Zipper a -> a
-value = undefined 
+value = undefined
 
--- | Get the left child of the focus node, if any.
 left :: Zipper a -> Maybe (Zipper a)
 left = undefined
 
--- | Get the right child of the focus node, if any.
 right :: Zipper a -> Maybe (Zipper a)
 right = undefined
 
--- | Get the parent of the focus node, if any.
 up :: Zipper a -> Maybe (Zipper a)
 up = undefined
 
--- | Set the value of the focus node.
 setValue :: a -> Zipper a -> Zipper a
 setValue = undefined
 
--- | Replace a left child tree.
 setLeft :: Maybe (BinTree a) -> Zipper a -> Zipper a
-setLeft = undefined 
+setLeft = undefined
 
--- | Replace a right child tree.
 setRight :: Maybe (BinTree a) -> Zipper a -> Zipper a
 setRight = undefined


### PR DESCRIPTION
- Rewrite test to use `hspec` with fail-fast.
- Remove comments from stub solution.

Related to #211 and #302.