### PR TITLE
forth: Rewrite tests to use hspec with fail-fast.

### DIFF
--- a/exercises/forth/package.yaml
+++ b/exercises/forth/package.yaml
@@ -18,4 +18,4 @@ tests:
     source-dirs: test
     dependencies:
       - forth
-      - HUnit
+      - hspec


### PR DESCRIPTION
- Rewrite tests to use `hspec`.
- ~~~Move hint from test suite to `HINTS.md`.~~~

Related to #211.