### PR TITLE
crypto-square: Completely rewrite tests.

### DIFF
--- a/exercises/crypto-square/src/CryptoSquare.hs
+++ b/exercises/crypto-square/src/CryptoSquare.hs
@@ -1,18 +1,4 @@
-module CryptoSquare
-    ( ciphertext
-    , normalizeCiphertext
-    , normalizePlaintext
-    , plaintextSegments
-    ) where
+module CryptoSquare (encode) where
 
-ciphertext :: String -> String
-ciphertext = undefined
-
-normalizeCiphertext :: String -> String
-normalizeCiphertext = undefined
-
-normalizePlaintext :: String -> String
-normalizePlaintext = undefined
-
-plaintextSegments :: String -> [String]
-plaintextSegments = undefined
+encode :: String -> String
+encode = undefined

--- a/exercises/crypto-square/src/Example.hs
+++ b/exercises/crypto-square/src/Example.hs
@@ -1,23 +1,15 @@
-module CryptoSquare ( normalizePlaintext
-                    , plaintextSegments
-                    , ciphertext
-                    , normalizeCiphertext ) where
+module CryptoSquare (encode) where
 
-import Data.Char (isAlphaNum, toLower)
-import Data.List (transpose)
+import Data.Char       (isAlphaNum, toLower)
+import Data.List       (transpose)
 import Data.List.Split (chunksOf)
 
-squareSize :: String -> Int
-squareSize = ceiling . (sqrt :: Double -> Double) . fromIntegral . length
-
-normalizePlaintext :: String -> String
-normalizePlaintext = map toLower . filter isAlphaNum
-
-plaintextSegments :: String -> [String]
-plaintextSegments = (squareSize >>= chunksOf) . normalizePlaintext
-
-ciphertext :: String -> String
-ciphertext = concat . transpose . plaintextSegments
-
-normalizeCiphertext :: String -> String
-normalizeCiphertext = unwords . transpose . plaintextSegments
+encode :: String -> String
+encode = unwords
+       . transpose
+       . (squareSize >>= chunksOf)
+       . map toLower
+       . filter isAlphaNum
+  where
+    squareSize :: String -> Int
+    squareSize = ceiling . (sqrt :: Double -> Double) . fromIntegral . length


### PR DESCRIPTION
This is a first draft of a new test suite based on what is being discussed in #259.

This diverges completely from `x-common`.

The test cases here are just examples of what needs to be tested, but the texts should probably be changed.

