### PR TITLE
anagram: Make the test suite as flexible as possible

### DIFF
--- a/exercises/anagram/HINTS.md
+++ b/exercises/anagram/HINTS.md
@@ -1,0 +1,22 @@
+## Hints
+
+To complete this exercise you need to implement the function `anagramsFor`,
+that takes a *word* and a group of *words*, returning the ones that are
+anagrams of the given *word*.
+
+If it is your first time solving this exercise, it is recommended that you
+stick to the provided signature:
+
+```haskell
+anagramsFor :: String -> [String] -> [String]
+```
+
+Later, it may be a good idea to revisit this problem and play with other data
+types and libraries:
+
+- `Text`, from package *text*.
+- `Sequence` and `Set`, from package *containers*.
+- `MultiSet`, from package *multiset*
+
+The test suite was intentionally designed to accept almost any type signature
+that makes sense, so you are encouraged to find the one you think is the best.

--- a/exercises/anagram/package.yaml
+++ b/exercises/anagram/package.yaml
@@ -9,6 +9,9 @@ library:
   dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
+    - containers
+    - multiset
+    - text
 
 tests:
   test:

--- a/exercises/anagram/src/Example.hs
+++ b/exercises/anagram/src/Example.hs
@@ -1,10 +1,13 @@
 module Anagram (anagramsFor) where
-import Data.List (sort)
-import Data.Char (toLower)
 
-anagramsFor :: String -> [String] -> [String]
-anagramsFor word = filter (isAnagram . normalize)
+import Data.Function  (on)
+import Data.MultiSet  (fromList)
+import Data.Set       (Set, filter)
+import Data.Text      (Text, toLower, unpack)
+import Prelude hiding (filter)
+
+anagramsFor :: Text -> Set Text -> Set Text
+anagramsFor x = filter (\w -> x `isDistinctOf` w && x `isAnagramOf` w)
   where
-    normalize xs = let nxs = map toLower xs in (nxs, sort nxs)
-    (nw, sw) = normalize word
-    isAnagram (w, s) = nw /= w && sw == s
+    isDistinctOf = (/=) `on` toLower
+    isAnagramOf  = (==) `on` fromList . unpack . toLower

--- a/exercises/anagram/test/Tests.hs
+++ b/exercises/anagram/test/Tests.hs
@@ -1,7 +1,8 @@
 {-# LANGUAGE RecordWildCards #-}
 
 import Data.Foldable     (for_)
-import Test.Hspec        (Spec, describe, it, shouldBe)
+import GHC.Exts          (fromList, toList)
+import Test.Hspec        (Spec, describe, it, shouldMatchList)
 import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
 
 import Anagram (anagramsFor)
@@ -14,9 +15,14 @@ specs = describe "anagram" $
           describe "anagramsFor" $ for_ cases test
   where
 
-    test Case{..} = it description $ expression `shouldBe` expected
+    test Case{..} = it description $ expression `shouldMatchList` expected
       where
-        expression = anagramsFor subject candidates
+        expression = map toList
+                   . toList
+                   . anagramsFor (fromList subject)
+                   . fromList
+                   . map fromList
+                   $ candidates
 
 -- Test cases adapted from `exercism/x-common/anagrams.json` on 2016-07-25.
 


### PR DESCRIPTION
For a while, we are doings things that seem to increase the number of solutions accepted by the test suites:

- In #144 we fixed some exercises to allow polymorphic solutions to compile without warnings.
- In #211, we rewrote most of the test suites. In the process, some of the tests were changed to allow more general numeric types.
- In #391, we changed `crypto-square` to stop testing for intermediary functions, and test only for the essential properties of the solution.
- In #392, we recently agreed that we should ignore the order of the words returned by `anagramsFor`, because the order *is not an essential part of the problem*.

All of those things where based on the same idea: **To allow more diverse solutions**.

This seems to be aligned to what was discussed in exercism/discussions#41 and exercism/discussions#44.

Taking this process to the next level, if the essence of the `anagram` problem is to find anagrams, there is no reason to restrict the solutions to work only on *Strings* and *Lists*. The following signatures seem equally reasonable:

```haskell
anagramsFor :: String ->          [String] ->          [String]
anagramsFor :: String -> Sequence  String  -> Sequence  String
anagramsFor :: String -> Set       String  -> Set       String
anagramsFor :: Text   ->          [Text]   ->          [Text]
anagramsFor :: Text   -> Sequence  Text    -> Sequence  Text
anagramsFor :: Text   -> Set       Text    -> Set       Text
```

This PR is an experiment on trying to write the most general possible test suite, allowing users to create beautiful solutions using important libraries that are usually not allowed in most of the exercises.

Closes #392.