### PR TITLE
leap: Add type signature and HINTS.md.

### DIFF
--- a/exercises/leap/HINTS.md
+++ b/exercises/leap/HINTS.md
@@ -1,0 +1,11 @@
+## Hints
+
+To complete this exercise you need to implement the function `isLeapYear`,
+that takes a year and determines whether it is a leap year.
+
+You can use the provided signature if you are unsure about the types, but
+don't let it restrict your creativity:
+
+```haskell
+isLeapYear :: Integer -> Bool
+```

--- a/exercises/leap/src/LeapYear.hs
+++ b/exercises/leap/src/LeapYear.hs
@@ -1,3 +1,4 @@
 module LeapYear (isLeapYear) where
 
+isLeapYear :: Integer -> Bool
 isLeapYear = undefined


### PR DESCRIPTION
This is an introductory exercise, so I think we should make things easier for the students. Most newcomers are still struggling to understand Haskell's type system and a signature can help a lot. 

The `HINTS.md` was added just to give the idea that the provided signature is not the only possible one.

I know that some people will disagree about it, saying that finding the type signatures is part of the problem, but if we make it too hard, a lot of people will give up. The ability to understand the types and the test suites will come with practice.

I believe that, as a rule, we should provide stub solutions with type signatures that allow compiling and running the tests whenever possible. Some exercises do not allow that - because that is the main challenge - and the students will have the opportunity to deal with the problem of finding compatible type signatures and create the proper data types.