### PR TITLE
new exercise zebra-puzzle

### DIFF
--- a/config.json
+++ b/config.json
@@ -251,6 +251,12 @@
       ]
     },
     {
+      "slug": "zebra-puzzle",
+      "difficulty": 1,
+      "topics": [
+      ]
+    },
+    {
       "slug": "minesweeper",
       "difficulty": 1,
       "topics": [

--- a/exercises/zebra-puzzle/package.yaml
+++ b/exercises/zebra-puzzle/package.yaml
@@ -1,0 +1,19 @@
+name: zebra-puzzle
+
+dependencies:
+  - base
+
+library:
+  exposed-modules: ZebraPuzzle
+  source-dirs: src
+  dependencies:
+  # - foo       # List here the packages you
+  # - bar       # want to use in your solution.
+
+tests:
+  test:
+    main: Tests.hs
+    source-dirs: test
+    dependencies:
+      - zebra-puzzle
+      - hspec

--- a/exercises/zebra-puzzle/src/Example.hs
+++ b/exercises/zebra-puzzle/src/Example.hs
@@ -1,0 +1,113 @@
+module ZebraPuzzle (Resident(..), Solution(..), solve) where
+
+import Control.Monad (guard)
+import Data.List (nub, find)
+import Data.Maybe (fromJust)
+
+data Color = Red | Green | Yellow | Blue | Ivory
+  deriving (Eq, Show, Enum)
+data Resident = Englishman | Spaniard | Ukrainian | Norwegian | Japanese
+  deriving (Eq, Show, Enum)
+data Pet = Dog | Snails | Fox | Horse | Zebra
+  deriving (Eq, Show, Enum)
+data Beverage = Coffee | Tea | Milk | OrangeJuice | Water
+  deriving (Eq, Show, Enum)
+data Cigarette = OldGold | Kools | Chesterfields | LuckyStrike | Parliaments
+  deriving (Eq, Show, Enum)
+data Position = One | Two | Three | Four | Five
+  deriving (Eq, Show, Enum)
+
+data House = House { position :: Position
+                   , color :: Color
+                   , resident :: Resident
+                   , beverage :: Beverage
+                   , cigarette :: Cigarette
+                   , pet :: Pet
+                   } deriving (Show)
+
+data Solution = Solution { waterDrinker :: Resident
+                         , zebraOwner :: Resident
+                         } deriving (Eq, Show)
+
+solve :: Solution
+solve = Solution waterDrinker' zebraOwner'
+  where
+    waterDrinker' = residentWith beverage Water
+    zebraOwner'   = residentWith pet Zebra
+    residentWith :: (Eq a) => (House -> a) -> a -> Resident
+    residentWith what value = resident $ houseWith what value fiveHouses
+
+fiveHouses :: [House]
+fiveHouses = head $ do
+  one   <- housesAtPosition One
+  two   <- housesAtPosition Two
+  guard $ uniqueHouses [one, two]   -- prune search tree as early as possible
+  three <- housesAtPosition Three
+  guard $ uniqueHouses [one, two, three]
+  four  <- housesAtPosition Four
+  guard $ uniqueHouses [one, two, three, four]
+  five  <- housesAtPosition Five
+  let candidates = [one, two, three, four, five]
+  guard $ uniqueHouses candidates
+  guard $ validPositions candidates
+  return candidates
+  where
+    housesAtPosition :: Position -> [House]
+    housesAtPosition pos = filter ((== pos) . position) validHouses
+
+validHouses :: [House]
+validHouses = do
+  position' <- [One .. Five]
+  color' <- [Red .. Ivory]
+  resident' <- [Englishman .. Japanese]
+  beverage' <- [Coffee .. Water]
+  cigarette' <- [OldGold .. Parliaments]
+  pet' <- [Dog .. Zebra]
+  let house = House position' color' resident' beverage' cigarette' pet'
+  guard $ validHouse house
+  return house
+
+validHouse :: House -> Bool
+validHouse (House position' color' resident' beverage' cigarette' pet') =
+  all (uncurry iff) [
+    (color' == Red, resident' == Englishman),
+    (resident' == Spaniard, pet' == Dog),
+    (color' == Green, beverage' == Coffee),
+    (resident' == Ukrainian, beverage' == Tea),
+    (cigarette' == OldGold, pet' == Snails),
+    (color' == Yellow, cigarette' == Kools),
+    (position' == Three, beverage' == Milk),
+    (position' == One, resident' == Norwegian),
+    (beverage' == OrangeJuice, cigarette' == LuckyStrike),
+    (resident' == Japanese, cigarette' == Parliaments)
+  ]
+
+iff :: Bool -> Bool -> Bool
+iff True  True  = True
+iff False False = True
+iff _     _     = False
+
+uniqueHouses :: [House] -> Bool
+uniqueHouses houses =
+  unique color && unique resident && unique beverage &&
+  unique cigarette && unique pet
+  where
+    unique :: (Eq a) => (House -> a) -> Bool
+    unique what = (== length houses) . length . nub $ map what houses
+
+houseWith :: (Eq a) => (House -> a) -> a -> [House] -> House
+houseWith what value = fromJust . find ((== value) . what)
+
+validPositions :: [House] -> Bool
+validPositions houses =
+  houseWith' color Green `toTheRight` houseWith' color Ivory &&
+  houseWith' cigarette Chesterfields `nextTo` houseWith' pet Fox &&
+  houseWith' cigarette Kools `nextTo` houseWith' pet Horse &&
+  houseWith' resident Norwegian `nextTo` houseWith' color Blue
+  where
+    houseWith' what value = houseWith what value houses
+    toTheRight :: House -> House -> Bool
+    toTheRight h1 h2 = fromEnum (position h1) == fromEnum (position h2) + 1
+    nextTo :: House -> House -> Bool
+    nextTo h1 h2 = abs (fromEnum (position h1) - fromEnum (position h2)) == 1
+

--- a/exercises/zebra-puzzle/src/ZebraPuzzle.hs
+++ b/exercises/zebra-puzzle/src/ZebraPuzzle.hs
@@ -1,0 +1,12 @@
+module ZebraPuzzle (Resident(..), Solution(..), solve) where
+
+data Resident = Englishman | Spaniard | Ukrainian | Norwegian | Japanese
+  deriving (Eq, Show)
+
+data Solution = Solution { waterDrinker :: Resident
+                         , zebraOwner :: Resident
+                         } deriving (Eq, Show)
+
+solve :: Solution
+solve = undefined
+

--- a/exercises/zebra-puzzle/stack.yaml
+++ b/exercises/zebra-puzzle/stack.yaml
@@ -1,0 +1,1 @@
+resolver: nightly-2016-07-17

--- a/exercises/zebra-puzzle/test/Tests.hs
+++ b/exercises/zebra-puzzle/test/Tests.hs
@@ -1,0 +1,32 @@
+{-# LANGUAGE RecordWildCards #-}
+
+import Data.Foldable     (for_)
+import Test.Hspec        (Spec, describe, it, shouldBe)
+import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+
+import ZebraPuzzle (Resident(..), Solution(..), solve)
+
+main :: IO ()
+main = hspecWith defaultConfig {configFastFail = True} specs
+
+specs :: Spec
+specs = describe "zebra-puzzle" $
+          describe "solve" $ for_ cases test
+  where
+
+    test Case{..} = it description assertion
+      where
+        assertion  = expression `shouldBe` solution
+        expression = solve
+
+data Case = Case { description :: String
+                 , solution    :: Solution
+                 }
+
+cases :: [Case]
+cases = [ Case { description  = "solution"
+               , solution    = Solution { waterDrinker = Norwegian
+                                        , zebraOwner = Japanese
+                                        }
+               }
+        ]

--- a/exercises/zebra-puzzle/test/Tests.hs
+++ b/exercises/zebra-puzzle/test/Tests.hs
@@ -1,6 +1,3 @@
-{-# LANGUAGE RecordWildCards #-}
-
-import Data.Foldable     (for_)
 import Test.Hspec        (Spec, describe, it, shouldBe)
 import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
 
@@ -11,22 +8,6 @@ main = hspecWith defaultConfig {configFastFail = True} specs
 
 specs :: Spec
 specs = describe "zebra-puzzle" $
-          describe "solve" $ for_ cases test
-  where
+          it "solve" $ solve `shouldBe` Solution { waterDrinker = Norwegian
+                                                 , zebraOwner   = Japanese  }
 
-    test Case{..} = it description assertion
-      where
-        assertion  = expression `shouldBe` solution
-        expression = solve
-
-data Case = Case { description :: String
-                 , solution    :: Solution
-                 }
-
-cases :: [Case]
-cases = [ Case { description  = "solution"
-               , solution    = Solution { waterDrinker = Norwegian
-                                        , zebraOwner = Japanese
-                                        }
-               }
-        ]


### PR DESCRIPTION
The `Tests.hs` are pretty degenerated as they consist of just one test. So they could be simplified, but I did not want to interfere with the usual format.
And of course the position of the exercise in `config.json` can be changed. This is just some more or less arbitrary guess of mine.
There is this [Logic programming example](https://wiki.haskell.org/Logic_programming_example). I tried to be somewhat close to this one with my `Example.hs`. So we could consider to add this link as a hint.