### PR TITLE
word-count: Generalize test suite.

### DIFF
--- a/exercises/word-count/HINTS.md
+++ b/exercises/word-count/HINTS.md
@@ -1,0 +1,21 @@
+## Hints
+
+To complete this exercise you need to implement the function `wordCount`,
+that takes a *text* and returns how many times each *word* appears.
+
+If it is your first time solving this exercise, it is recommended that you
+stick to the provided signature:
+
+```haskell
+wordCount :: String -> [(String, Int)]
+```
+
+Later, it may be a good idea to revisit this problem and play with other data
+types and libraries:
+
+- `Text`, from package *text*.
+- `Map`, from package *containers*.
+- `MultiSet`, from package *multiset*
+
+The test suite was intentionally designed to accept almost any type signature
+that makes sense, so you are encouraged to find the one you think is the best.

--- a/exercises/word-count/examples/success-newtype/WordCount.hs
+++ b/exercises/word-count/examples/success-newtype/WordCount.hs
@@ -1,0 +1,31 @@
+{-# LANGUAGE TypeFamilies #-}
+
+module WordCount (wordCount) where
+
+import Prelude hiding (null)
+import Data.Char      (isAlphaNum)
+import Data.Text      (Text, null, split, toLower)
+import Data.MultiSet  (MultiSet, Occur, fromList, fromOccurList, toOccurList)
+
+import qualified GHC.Exts (IsList(..))
+
+wordCount :: Text -> Bag Text
+wordCount = Bag
+          . fromList
+          . map toLower
+          . wordsBy (not . isAlphaNum)
+
+-- The `text` package misses this function that
+-- exists in package `split`, but works on lists.
+wordsBy :: (Char -> Bool) -> Text -> [Text]
+wordsBy p = filter (not . null) . split p
+
+-- MultiSet is not an instance of `IsList`, so we create
+-- a newtype to wrap it, avoiding an orphan instance.
+newtype Bag a = Bag { toMultiSet :: MultiSet a }
+
+instance (Ord a) => GHC.Exts.IsList (Bag a)
+  where
+    type Item (Bag a) = (a, Occur)
+    fromList = Bag . fromOccurList
+    toList   = toOccurList . toMultiSet

--- a/exercises/word-count/examples/success-newtype/package.yaml
+++ b/exercises/word-count/examples/success-newtype/package.yaml
@@ -9,6 +9,8 @@ library:
   dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
+    - multiset
+    - text
 
 tests:
   test:

--- a/exercises/word-count/examples/success-simple/WordCount.hs
+++ b/exercises/word-count/examples/success-simple/WordCount.hs
@@ -1,0 +1,13 @@
+module WordCount (wordCount) where
+
+import Control.Arrow   ((&&&))
+import Data.Char       (toLower, isAlphaNum)
+import Data.List       (group, sort)
+import Data.List.Split (wordsBy)
+
+wordCount :: String -> [(String, Int)]
+wordCount = map (head &&& length)
+          . group
+          . sort
+          . map (map toLower)
+          . wordsBy (not . isAlphaNum)

--- a/exercises/word-count/examples/success-simple/package.yaml
+++ b/exercises/word-count/examples/success-simple/package.yaml
@@ -9,6 +9,7 @@ library:
   dependencies:
   # - foo       # List here the packages you
   # - bar       # want to use in your solution.
+    - split
 
 tests:
   test:

--- a/exercises/word-count/src/Example.hs
+++ b/exercises/word-count/src/Example.hs
@@ -1,8 +1,0 @@
-module WordCount (wordCount) where
-import Data.Char (toLower, isAlphaNum)
-import Data.Map.Strict (Map, fromListWith)
-import Data.List.Split (wordsBy)
-
-wordCount :: String -> Map String Int
-wordCount = fromListWith (+) . map pair . wordsBy (not . isAlphaNum)
-  where pair word = (map toLower word, 1)

--- a/exercises/word-count/src/WordCount.hs
+++ b/exercises/word-count/src/WordCount.hs
@@ -1,3 +1,4 @@
 module WordCount (wordCount) where
 
-wordCount = undefined
+wordCount :: String -> [(String, Int)]
+wordCount xs = undefined

--- a/exercises/word-count/test/Tests.hs
+++ b/exercises/word-count/test/Tests.hs
@@ -1,9 +1,11 @@
 {-# OPTIONS_GHC -fno-warn-type-defaults #-}
 {-# LANGUAGE RecordWildCards #-}
 
+import Data.Bifunctor    (bimap)
+import Data.Char         (toLower)
 import Data.Foldable     (for_)
-import Data.Map          (fromList)
-import Test.Hspec        (Spec, describe, it, shouldBe)
+import GHC.Exts          (fromList, toList)
+import Test.Hspec        (Spec, describe, it, shouldMatchList)
 import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
 
 import WordCount (wordCount)
@@ -15,11 +17,18 @@ specs :: Spec
 specs = describe "word-count" $
           describe "wordCount" $ for_ cases test
   where
-
-    test Case{..} = it description $ returnedMap `shouldBe` expectedMap
+    -- Here we used `fromIntegral`, `fromList` and `toList` to generalize
+    -- the tests, accepting any function that receives a string-like argumment
+    -- and returns a type that can be converted to [(String, Integer)].
+    -- Also, the words are lower-cased before comparison and the output's
+    -- order is ignored.
+    test Case{..} = it description $ expression `shouldMatchList` expected
       where
-        returnedMap = wordCount input
-        expectedMap = fromIntegral <$> fromList expected
+        expression = map (bimap (map toLower . toList) fromIntegral)
+                   . toList
+                   . wordCount
+                   . fromList
+                   $ input
 
 -- Test cases adapted from `exercism/x-common/word-count.json` on 2016-07-26.
 


### PR DESCRIPTION
- Generalize the test suite to accept multiple signatures.
- Change the test suite to be case insensitive.
- Add `HINTS.md` explaining that the test suite is flexible.
- Add two example solutions: one very simple; the other with a custom type.
- Add the simplest type signature to the stub solution.
- Remove unneeded dependencies from `package.yaml`.
- Remove old example solution.

These changes tries to make this exercise, at the same time, more accessible and deeper. Beginners will probably be able to solve it easily, while more advanced students will be able the craft more elaborated solutions.

Also, we used `shouldMatchList` to improve error reporting and we normalize case before comparing, because the output's case *is not an essential part of the problem*.

This PR is very similar to #393, that changed `anagram` to be more flexible, and it is also compatible with previously working solutions.