### PR TITLE
leap: Add variable to stub solution's signature.

### DIFF
--- a/exercises/leap/src/LeapYear.hs
+++ b/exercises/leap/src/LeapYear.hs
@@ -1,4 +1,4 @@
 module LeapYear (isLeapYear) where
 
 isLeapYear :: Integer -> Bool
-isLeapYear = undefined
+isLeapYear year = undefined


### PR DESCRIPTION
Considering that `leap` is the first exercise of the track, this small change may help a beginner, because (he|she) may think that the part before `=` should not be changed.

More experienced students will certainly already know that they can eta-reduce the functions, so I think there is no harm.

To make the exercises more accessible to newcomers, I believe it is in general a good think to have a stub solution that:

- Includes the simplest type signature acceptable by the test suite.
- Includes a [eta-abstracted](https://wiki.haskell.org/Eta_conversion) fake implementation with reasonable variable names. I have been using `undefined` as the function body.
- Compiles and fails the tests, if possible without ruining the challenge.

What do you think about it, @petertseng?