### PR TITLE
space-age: Add warning about tests not compiling.

### DIFF
--- a/exercises/space-age/HINTS.md
+++ b/exercises/space-age/HINTS.md
@@ -11,3 +11,6 @@ don't let it restrict your creativity:
 ```haskell
 ageOn :: Planet -> Float -> Float
 ```
+
+Keep in mind that the test suite will not compile until you correctly
+implement the data type `Planet`.


### PR DESCRIPTION
This is the first exercise in the track that fails compilation with the stub solution. We didn't had a complaint about it, but it may by a good idea to add a paragraph in `HINTS.md` explaining that it will not compile unless `Planet` is correctly implemented.

Should we do it?