### PR TITLE
new exercise alphametics

### DIFF
--- a/config.json
+++ b/config.json
@@ -371,6 +371,12 @@
       ]
     },
     {
+      "slug": "alphametics",
+      "difficulty": 7,
+      "topics": [
+      ]
+    },
+    {
       "slug": "connect",
       "difficulty": 8,
       "topics": [

--- a/exercises/alphametics/HINTS.md
+++ b/exercises/alphametics/HINTS.md
@@ -1,0 +1,5 @@
+## Hints
+
+You can solve this exercise with a brute force algorithm, but this will possibly have a poor runtime performance.
+Try to find a more sophisticated solution. Hint: You could try the column-wise addition algorithm that is usually taught in high school.
+

--- a/exercises/alphametics/package.yaml
+++ b/exercises/alphametics/package.yaml
@@ -1,0 +1,20 @@
+name: alphametics
+
+dependencies:
+  - base
+
+library:
+  exposed-modules: Alphametics
+  source-dirs: src
+  dependencies:
+  # - foo       # List here the packages you
+  # - bar       # want to use in your solution.
+    - parsec
+
+tests:
+  test:
+    main: Tests.hs
+    source-dirs: test
+    dependencies:
+      - alphametics
+      - hspec

--- a/exercises/alphametics/src/Alphametics.hs
+++ b/exercises/alphametics/src/Alphametics.hs
@@ -1,0 +1,4 @@
+module Alphametics (solve) where
+
+solve :: String -> Maybe [(Char, Int)]
+solve puzzle = undefined

--- a/exercises/alphametics/src/Example.hs
+++ b/exercises/alphametics/src/Example.hs
@@ -1,0 +1,116 @@
+{-# LANGUAGE GADTs #-}
+module Alphametics (solve) where
+
+import Control.Monad (guard)
+import Data.List (foldl', find, union)
+import Data.Maybe (fromJust, isJust, listToMaybe)
+import Prelude hiding (Word)
+import Text.Parsec
+import Text.Parsec.String
+
+type Solution = [(Char, Int)]
+
+solve :: String -> Maybe Solution
+solve puzzle = do
+  boolTerm' <- parseTerm puzzle
+  let columns = [0..maxLength boolTerm' - 1]
+      emptySolutions = [([], (0, 0))]
+      solutions = foldl' (flip $ partialSolutions boolTerm') emptySolutions columns
+  fst <$> listToMaybe solutions
+
+parseTerm :: String -> Maybe (Term Bool)
+parseTerm str = either (const Nothing) Just parseResult
+  where parseResult = parse boolTerm "boolTerm" str
+
+type PartialResult = (Integer, Integer) -- (result, carry)
+type PartialSolution = (Solution, PartialResult)
+
+partialSolutions :: Term a -> Int -> [PartialSolution] -> [PartialSolution]
+partialSolutions (Word xs) col solutionsSoFar
+  | col >= length xs = solutionsSoFar -- pass, no more constraints from this word
+  | otherwise = mergePartialSolutions takeChar charSolutions solutionsSoFar
+  where
+    charSolutions = toCharSolution <$> [if firstChar then 1 else 0..9]
+    char' = reverse xs !! col  -- process from the right
+    firstChar = head xs == char'
+    toCharSolution x = ([(char', x)], (toInteger x, 0))
+    takeChar (x, _) (_, y) = Just (x, y)
+partialSolutions (Plus left right) col solutionsSoFar =
+  mergePartialSolutions addResults leftSolutions rightSolutions
+  where
+    leftSolutions = partialSolutions left col solutionsSoFar
+    rightSolutions = partialSolutions right col solutionsSoFar
+    addResults (x1, x2) (y1, _) = Just (x1 + y1, x2)
+partialSolutions (Equals left right) col solutionsSoFar =
+  mergePartialSolutions equateResults leftSolutions rightSolutions
+  where
+    equateResults (leftResult, leftCarry) (rightResult, _)
+      | rightResult == requiredResult = Just (0, carry)
+      | otherwise = Nothing
+      where (carry, requiredResult) = (leftResult + leftCarry) `divMod` 10
+    leftSolutions = partialSolutions left col solutionsSoFar
+    rightSolutions = partialSolutions right col solutionsSoFar
+
+mergePartialSolutions :: (PartialResult -> PartialResult -> Maybe PartialResult) ->
+  [PartialSolution] -> [PartialSolution] -> [PartialSolution]
+mergePartialSolutions mergeResults xs ys = do
+  (xSolution, xResult) <- xs
+  (ySolution, yResult) <- ys
+  let mergedSolution = mergeSolutions xSolution ySolution
+  guard $ (not . null) mergedSolution
+  let mergedResult = mergeResults xResult yResult
+  guard $ isJust mergedResult
+  return (mergedSolution, fromJust mergedResult)
+  where
+    mergeSolutions :: Solution -> Solution -> Solution
+    mergeSolutions s1 s2
+      | any conflict s1 = []
+      | otherwise       = s1 `union` s2
+      where
+        conflict (k1, v1) =
+          maybe False (/= v1) (lookup k1 s2) ||
+          maybe False ((/= k1) . fst) (find ((== v1) . snd) s2)
+
+data Term a where
+  Word :: String -> Term Integer
+  Equals :: (Eq a) => Term a -> Term a -> Term Bool
+  Plus :: Term Integer -> Term Integer -> Term Integer
+
+maxLength :: Term a -> Int
+maxLength (Word xs) = length xs
+maxLength (Equals l r) = max (maxLength l) (maxLength r)
+maxLength (Plus   l r) = max (maxLength l) (maxLength r)
+
+-- Term Parser
+boolTerm :: Parser (Term Bool)
+boolTerm = do
+  left  <- integerTerm
+  _     <- trimmed (string "==")
+  right <- integerTerm
+  return $ Equals left right
+
+integerTerm :: Parser (Term Integer)
+integerTerm = try integerOperation <|> simpleIntegerTerm
+
+integerOperation :: Parser (Term Integer)
+integerOperation = do
+  left  <- simpleIntegerTerm
+  op    <- integerOperator
+  right <- integerTerm
+  return $ op left right
+
+simpleIntegerTerm :: Parser (Term Integer)
+simpleIntegerTerm = word
+
+integerOperator :: Parser (Term Integer -> Term Integer -> Term Integer)
+integerOperator = plus
+
+word :: Parser (Term Integer)
+word = Word <$> many1 upper
+
+plus :: Parser (Term Integer -> Term Integer -> Term Integer)
+plus = trimmed (char '+') *> pure Plus
+
+trimmed :: Parser a -> Parser a
+trimmed p = spaces *> p <* spaces
+

--- a/exercises/alphametics/stack.yaml
+++ b/exercises/alphametics/stack.yaml
@@ -1,0 +1,1 @@
+resolver: nightly-2016-07-17

--- a/exercises/alphametics/test/Tests.hs
+++ b/exercises/alphametics/test/Tests.hs
@@ -1,0 +1,78 @@
+{-# LANGUAGE RecordWildCards #-}
+
+import Data.Foldable     (for_)
+import Data.Function     (on)
+import Data.List         (sort)
+import Test.Hspec        (Spec, describe, it, shouldBe)
+import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
+
+import Alphametics (solve)
+
+main :: IO ()
+main = hspecWith defaultConfig {configFastFail = True} specs
+
+specs :: Spec
+specs = describe "alphametics" $
+          describe "solve" $ for_ cases test
+  where
+
+    test Case{..} = it description assertion
+      where
+        shouldMatchSolution = shouldBe `on` fmap sort
+        assertion = solve puzzle `shouldMatchSolution` expected
+
+-- Test cases adapted from `exercism/x-common/exercises/alphametics/canonical-data.json` on 2016-10-26.
+
+data Case = Case { description :: String
+                 , puzzle      :: String
+                 , expected    :: Maybe[(Char, Int)]
+                 }
+
+cases :: [Case]
+cases = [ Case { description = "puzzle with three letters"
+               , puzzle      = "I + BB == ILL"
+               , expected    = Just [('I', 1), ('B', 9), ('L', 0)]
+               }
+        , Case { description = "solution must have unique value for each letter"
+               , puzzle      = "A == B"
+               , expected    = Nothing
+               }
+        , Case { description = "leading zero solution is invalid"
+               , puzzle      = "ACA + DD == BD"
+               , expected    = Nothing
+               }
+        , Case { description = "puzzle with four letters"
+               , puzzle      = "AS + A == MOM"
+               , expected    = Just [('A', 9), ('S', 2), ('M', 1), ('O', 0)]
+               }
+        , Case { description = "puzzle with six letters"
+               , puzzle      = "NO + NO + TOO == LATE"
+               , expected    = Just [('N', 7), ('O', 4), ('T', 9), ('L', 1),
+                                      ('A', 0), ('E', 2)]
+               }
+        , Case { description = "puzzle with seven letters"
+               , puzzle      = "HE + SEES + THE == LIGHT"
+               , expected    = Just [('E', 4), ('G', 2), ('H', 5), ('I', 0),
+                                      ('L', 1), ('S', 9), ('T', 7)]
+               }
+        , Case { description = "puzzle with eight letters"
+               , puzzle      = "SEND + MORE == MONEY"
+               , expected    = Just [('S', 9), ('E', 5), ('N', 6), ('D', 7), ('M', 1),
+                                      ('O', 0), ('R', 8), ('Y', 2)]
+               }
+        -- some more (and more demanding) tests
+--        , Case { description  = "puzzle with ten letters"
+--               , puzzle       = "AND + A + STRONG + OFFENSE + AS + A + GOOD == DEFENSE"
+--               , expected     = Just [('A', 5), ('D', 3), ('E', 4), ('F', 7), ('G', 8),
+--                                      ('N', 0), ('O', 2), ('R', 1), ('S', 6), ('T', 9)]
+--               }
+--        , Case { description  = "puzzle with multiplication"
+--               , puzzle       = "IF * DR == DORI"
+--               , expected     = Just [('I', 8), ('F', 2), ('D', 3), ('R', 9), ('O', 1)]
+--               }
+--        , Case { description  = "puzzle with exponents"
+--               , puzzle       = "PI * R ^ 2 == AREA"
+--               , expected     = Just [('P', 9), ('I', 6), ('R', 7), ('A', 4), ('E', 0)]
+--               }
+        ]
+


### PR DESCRIPTION
of course feel free to change the place of the exercise in `config.json`. First I thought it makes sense to have it after `sgf-parsing` but then I saw its difficulty of 9 and reconsidered.
I kept the tests for multiplication and exponentiation from a former version of `canconical-data.json` as they make the exercise more interesting.
what annoys me is the more than 30 times worse performance than my same (I think) Scala implementation. would be very much interested to know the reason why.