### PR TITLE
say: Declare compliance with x-common

### DIFF
--- a/exercises/say/test/Tests.hs
+++ b/exercises/say/test/Tests.hs
@@ -19,8 +19,7 @@ specs = describe "say" $
         description = show n
         assertion   = inEnglish n `shouldBe` expected
 
-    -- As of 2016-09-12, there was no reference file
-    -- for the test cases in `exercism/x-common`.
+    -- Test cases adapted from `exercism/x-common/say` on 2016-11-06.
 
     cases = [ (            0, Just "zero"                                )
             , (            1, Just "one"                                 )
@@ -41,4 +40,7 @@ specs = describe "say" $
                                    \three hundred twenty-one thousand \
                                    \one hundred twenty-three"            )
             , (           -1, Nothing                                    )
+         -- Even though the x-common tests have this case,
+         -- we decide not to test it, to give freedom to go to trillions if desired.
+         -- , (1000000000000, Nothing                                    )
             ]


### PR DESCRIPTION
Added in https://github.com/exercism/x-common/pull/399

Note that there is one place where we deviate:
We do not have an upper bound test.
This was discussed and decided in #292.
This deviation has been explicitly noted.