### PR TITLE
custom-set: change stub to make it compile.

### DIFF
--- a/exercises/custom-set/HINTS.md
+++ b/exercises/custom-set/HINTS.md
@@ -17,8 +17,9 @@ with `Eq` and `Show` instances, and implement the following functions:
 - `toList`
 - `union`
 
-You will find the type signatures already in place, but it is up to you
-to define the functions.
+You will find a dummy data declaration and type signatures already in place,
+but it is up to you to define the functions and create a meaningful data type,
+newtype or type synonym.
 
 If you're interested in writing an efficient implementation but don't quite
 know where to start, the best primer I know of is Chris Okasaki's

--- a/exercises/custom-set/src/CustomSet.hs
+++ b/exercises/custom-set/src/CustomSet.hs
@@ -1,6 +1,5 @@
 module CustomSet
-  ( CustomSet
-  , delete
+  ( delete
   , difference
   , empty
   , fromList
@@ -16,6 +15,8 @@ module CustomSet
   ) where
 
 import Prelude hiding (null)
+
+data CustomSet a = Dummy deriving (Eq, Show)
 
 delete :: a -> CustomSet a -> CustomSet a
 delete = undefined


### PR DESCRIPTION
This PR makes small changes to allow the stub solution to build and also compile the test suite.

The ability to run the tests with the stub solution is useful mainly for two reasons:

- It allows us to assert that the stub solution is "correct".
- It allows the students to have an easier start, also making it clear what needs to be implemented.

On the other hand, it has drawbacks:

- We are forced to create a dummy data definition, which makes the exercise a little less challenging.
- We cannot export the data constructors to the test suite, because they do not exist yet.

Considering that most of the students don't go too far in the track, I'm not too worried about the risk of making it too easy, so I think it is worthy to try this path.

Related to #421.