### PR TITLE
grains: add signatures to stub solution

### DIFF
--- a/exercises/grains/src/Grains.hs
+++ b/exercises/grains/src/Grains.hs
@@ -1,5 +1,7 @@
 module Grains (square, total) where
 
-square = undefined
+square :: Integer -> Maybe Integer
+square n = undefined
 
+total :: Integer
 total = undefined


### PR DESCRIPTION
Since we changed `grains` to expect a `Maybe` in https://github.com/exercism/xhaskell/pull/197, we had two users that opened issues about not being able to compile it: https://github.com/exercism/xhaskell/issues/305 and https://github.com/exercism/xhaskell/issues/430

The test suite seems correct, but users have a hard time trying to infer the correct types based on test suite.

This PR just add the expected type signatures to the stub solution.