### PR TITLE
list-ops: import/test filter function of exercise code

### DIFF
--- a/exercises/list-ops/test/Tests.hs
+++ b/exercises/list-ops/test/Tests.hs
@@ -7,6 +7,7 @@ import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
 import Prelude hiding
     ( (++)
     , concat
+    , filter
     , foldr
     , length
     , map
@@ -16,6 +17,7 @@ import Prelude hiding
 import ListOps
     ( (++)
     , concat
+    , filter
     , foldl'
     , foldr
     , length


### PR DESCRIPTION
Currently the list-ops exercise's test case neither hides `filter` from `Prelude` nor does it import that function from the exercise code. Hence the test cases don't test the users implementation but the Prelude one's ...