### PR TITLE
common: Add `stack.yaml` to common files folder and link `pov` as a test.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ script:
 
                 buildfolder="${TRAVIS_BUILD_DIR}/build/${exercisename}/${examplename}"
                 mkdir -p "${buildfolder}"
-                cp -r stack.yaml test ${example}/* "${buildfolder}"
+                cp -rL stack.yaml test ${example}/* "${buildfolder}"
 
                 pushd $buildfolder
 

--- a/common/stack.yaml
+++ b/common/stack.yaml
@@ -1,0 +1,1 @@
+resolver: lts-7.9

--- a/config.json
+++ b/config.json
@@ -439,6 +439,7 @@
     "trinary"
   ],
   "ignored": [
+    "common",
     "docs",
     "img"
   ],

--- a/exercises/pov/stack.yaml
+++ b/exercises/pov/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-7.9
+../../common/stack.yaml


### PR DESCRIPTION
As discussed in #442, it would be nice to have a single `stack.yaml` file and link all the others to it.

We expect this approach will work, but it is better to test fetching an exercise before making huge changes.

This PR does the following:

- Add `common/stack.yaml`
- Add `common` to ignore section in `config.json`
- Fix `.travis.yml` to dereference links when copying files for testing
- Symbolic link `stack.yaml` from exercism `pov`

Related to #442.