### PR TITLE
robot-name: Fix hlint-1.9.38 newtype warning

### DIFF
--- a/exercises/robot-name/examples/success-standard/src/Robot.hs
+++ b/exercises/robot-name/examples/success-standard/src/Robot.hs
@@ -4,7 +4,7 @@ import Control.Concurrent (MVar, readMVar, swapMVar, newMVar)
 import Control.Monad (void)
 import System.Random (randomRIO)
 
-data Robot = Robot { robotNameVar :: MVar String }
+newtype Robot = Robot { robotNameVar :: MVar String }
 
 mkRobot :: IO Robot
 mkRobot = fmap Robot $ generateName >>= newMVar


### PR DESCRIPTION
Patch example solution to fix the warning:

```
./exercises/robot-name/examples/success-standard/src/Robot.hs:7:1: Suggestion: Use newtype instead of data
Found:
  data Robot = Robot{robotNameVar :: MVar String}
Why not:
  newtype Robot = Robot{robotNameVar :: MVar String}
Note: decreases laziness

1 hint (5 ignored)
```

The `nightly` snapshot currently fails the tests in Travis-CI because of that warning.