### PR TITLE
difference-of-square: Comment out last test

### DIFF
--- a/exercises/difference-of-squares/test/Tests.hs
+++ b/exercises/difference-of-squares/test/Tests.hs
@@ -64,7 +64,9 @@ specs = describe "differenceOfSquares" $ do
           difference (12 :: Integer)
           `shouldBe` (5434 :: Integer)
 
+      {-
       describe "huge difference" $
         it "difference (1234567890 :: Integer)" $
           difference (1234567890 :: Integer)
           `shouldBe` (580764307309260838625720836817589660 :: Integer)
+      -}


### PR DESCRIPTION
The test `huge difference` has caused some difficulties
to users because the most common solutions use the `sum`
function, that seems to be implemented as a `foldr`.

A naive implementation would certainly fail the test or,
in the worst case scenario, allocate all the memory and
crash the operating system.

Closes #449.