### PR TITLE
pov: Revert linking `common/stack.yaml`

### DIFF
--- a/exercises/pov/stack.yaml
+++ b/exercises/pov/stack.yaml
@@ -1,1 +1,1 @@
-../../common/stack.yaml
+resolver: lts-7.9


### PR DESCRIPTION
The experiment proposed in #442 of symbolic linking the
`stack.yaml` file has failed, as the file was not fetched
as expected.

This PR partially reverts #443, but leaves the fix
in `.travis.yml` and the `common/stack.yaml` file.