### PR TITLE
pov: Add dummy symbolic link

### DIFF
--- a/exercises/pov/.dummylink
+++ b/exercises/pov/.dummylink
@@ -1,0 +1,1 @@
+../../common/stack.yaml


### PR DESCRIPTION
In #442 we conjectured that using symbolic links to a common `stack.yaml` would be feasible, but the test (#443) didn't work as expected. 

The result of the experiment was a `pov` exercise without a `stack.yaml` file, and #453 was opened on fix that.

To keep testing symbolic links, we still need to use `pov` as a test bed, but this time without breaking it, so we use another symbolic link name, unrelated to the exercise.