### PR TITLE
SETUP.md: Add for paranoia

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -1,0 +1,52 @@
+
+## Getting Started
+
+For installation and learning resources, refer to the
+[exercism help page](http://exercism.io/languages/haskell).
+
+## Running the tests
+
+To run the test suite, execute the following command:
+
+```bash
+stack test
+```
+
+#### If you get an error message like this...
+
+```
+No .cabal file found in directory
+```
+
+You are probably running an old stack version and need
+to upgrade it.
+
+#### Otherwise, if you get an error message like this...
+
+```
+No compiler found, expected minor version match with...
+Try running "stack setup" to install the correct GHC...
+```
+
+Just do as it says and it will download and install
+the correct compiler version:
+
+```bash
+stack setup
+```
+
+## Running *GHCi*
+
+If you want to play with your solution in GHCi, just run the command:
+
+```bash
+stack ghci
+```
+
+## Feedback, Issues, Pull Requests
+
+The [exercism/xhaskell](https://github.com/exercism/xhaskell) repository on
+GitHub is the home for all of the Haskell exercises.
+
+If you have feedback about an exercise, or want to help implementing a new
+one, head over there and create an issue. We'll do our best to help you!


### PR DESCRIPTION
In #462, we moved it to TRACK_HINTS.md

HOWEVER, we are the very first track to do so, so the code is untested.
It is possible something can go wrong.

If we want to be paranoid, we can add a SETUP.md so that if TRACK_HINTS
fails we don't leave our students in the dark.

This SETUP.md is slightly different from TRACK_HINTS.md: It has only one
space after the period on the last line, rather than two.

This way, we can tell which of the two files is being used.

---

Note to reviewers: We *do not necessarily* need to merge this. This all depends on how paranoid we are feeling. I have confidence in https://github.com/exercism/trackler/blob/master/lib/trackler/implementation.rb#L105 that our TRACK_HINTS.md is in the right place, but it is possible to be paranoid, and delete the SETUP.md file once we are sure it works.