### PR TITLE
travis: Build all stubs, and test all stubs except for untestable ones

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,27 @@ script:
         exercisename=$(basename "$exercise")
         pushd ${exercise}
 
+        examplename="stub"
+        buildfolder="${TRAVIS_BUILD_DIR}/build/${exercisename}/${examplename}"
+        mkdir -p "${buildfolder}"
+        cp -rL stack.yaml package.yaml src test "${buildfolder}"
+
+        pushd $buildfolder
+
+        examplecache="${HOME}/.foldercache/${exercisename}/${examplename}/.stack-work"
+        mkdir -p "$examplecache"
+        ln -f -s "$examplecache"
+
+        if [ -f "${exercise}/.meta/DONT-TEST-STUB" ]; then
+            echo "only building stub"
+            stack build ${SET_RESOLVER} --install-ghc --no-terminal
+        else
+            echo "testing stub"
+            stack test ${SET_RESOLVER} --install-ghc --no-terminal --no-run-tests
+        fi
+
+        popd
+
         if ! stat -t examples/*/ > /dev/null 2>&1; then
             echo "No examples for ${exercise}!"
             exit 1

--- a/README.md
+++ b/README.md
@@ -116,7 +116,13 @@ To fix a bug you should [create a pull request from a fork](https://help.github.
 You should have [Stack](http://docs.haskellstack.org/) installed in your system to make contributing to this repository easier.
 
 ### Stub solution
-The stub solution must compile together with the test suite. It should be as general as possible in order to not exclude any possible solutions. It should take Haskell specifics into account (for example use `Maybe` instead of a dummy return value). It should not contain any comments (people might forget to remove them), you can use the hints file instead.
+The stub solution should be as general as possible in order to not exclude any possible solutions. It should take Haskell specifics into account (for example use `Maybe` instead of a dummy return value). It should not contain any comments (people might forget to remove them), you can use the hints file instead.
+
+The stub solution must compile by itself (with `stack build`).
+Ideally, it would also compile together with the test suite (with `stack test --no-run-tests`).
+These two conditions are enforced by Travis.
+If the second condition cannot be met for a good reason, place the explanation in `.meta/DONT-TEST-STUB` to circumvent the check.
+The first condition is always enforced and cannot be circumvented.
 
 ### Example solution
 The example solution could be inspiration for other language implementors. It doesn't need to be perfect or very elegant. But it should be efficient enough for the test suite to finish in only a few seconds.

--- a/exercises/allergies/.meta/DONT-TEST-STUB
+++ b/exercises/allergies/.meta/DONT-TEST-STUB
@@ -1,0 +1,1 @@
+We would have to export all the allergens in the stub; let students figure that out.

--- a/exercises/allergies/HINTS.md
+++ b/exercises/allergies/HINTS.md
@@ -6,5 +6,6 @@ with `Eq` and `Show` instances, and implement the following functions:
 - `allergies`
 - `isAllergicTo`
 
-Your can use the provided signatures if you are unsure about the types, but
-don't let them restrict your creativity.
+You will find a dummy data declaration and type signatures already in place,
+but it is up to you to define the functions and create a meaningful data type,
+newtype or type synonym.

--- a/exercises/allergies/src/Allergies.hs
+++ b/exercises/allergies/src/Allergies.hs
@@ -1,5 +1,7 @@
 module Allergies (Allergen(..), allergies, isAllergicTo) where
 
+data Allergen = Dummy
+
 allergies :: Int -> [Allergen]
 allergies = undefined
 

--- a/exercises/bank-account/HINTS.md
+++ b/exercises/bank-account/HINTS.md
@@ -11,5 +11,6 @@ The amount may be negative for a withdrawal.
 
 The initial balance of the bank account should be 0.
 
-Your can use the provided signatures if you are unsure about the types, but
-don't let them restrict your creativity.
+You will find a dummy data declaration and type signatures already in place,
+but it is up to you to define the functions and create a meaningful data type,
+newtype or type synonym.

--- a/exercises/bank-account/src/BankAccount.hs
+++ b/exercises/bank-account/src/BankAccount.hs
@@ -6,6 +6,8 @@ module BankAccount
     , openAccount
     ) where
 
+data BankAccount = Dummy
+
 closeAccount :: BankAccount -> IO ()
 closeAccount = undefined
 

--- a/exercises/clock/.meta/DONT-TEST-STUB
+++ b/exercises/clock/.meta/DONT-TEST-STUB
@@ -1,0 +1,1 @@
+We ask for the Clock to be an instance of Num; let students figure this out.

--- a/exercises/clock/HINTS.md
+++ b/exercises/clock/HINTS.md
@@ -12,5 +12,6 @@ The function `fromInteger`, from `Num`, must convert minutes
 to 24 hour clock time. It is not necessary to have a sensible
 implementation of `abs` or `signum`.
 
-Your can use the provided signatures if you are unsure about the types, but
-don't let them restrict your creativity.
+You will find a dummy data declaration and type signatures already in place,
+but it is up to you to define the functions and create a meaningful data type,
+newtype or type synonym.

--- a/exercises/clock/src/Clock.hs
+++ b/exercises/clock/src/Clock.hs
@@ -1,5 +1,7 @@
 module Clock (clockHour, clockMin, fromHourMin, toString) where
 
+data Clock = Dummy
+
 clockHour :: Clock -> Int
 clockHour = undefined
 

--- a/exercises/grade-school/.meta/DONT-TEST-STUB
+++ b/exercises/grade-school/.meta/DONT-TEST-STUB
@@ -1,0 +1,2 @@
+No type signatures on functions (TODO: Should we have them?),
+and this makes it impossible to ensure that the result of `grade` is `Eq`.

--- a/exercises/grade-school/HINTS.md
+++ b/exercises/grade-school/HINTS.md
@@ -7,3 +7,7 @@ and implement the following functions:
 - `empty`
 - `grade`
 - `sorted`
+
+You will find a dummy data declaration already in place, but it is up to you to
+define the functions and create a meaningful data type, newtype or type
+synonym.

--- a/exercises/grade-school/src/School.hs
+++ b/exercises/grade-school/src/School.hs
@@ -1,5 +1,7 @@
 module School (School, add, empty, grade, sorted) where
 
+data School = Dummy
+
 add = undefined
 
 empty = undefined

--- a/exercises/largest-series-product/src/Series.hs
+++ b/exercises/largest-series-product/src/Series.hs
@@ -1,3 +1,4 @@
 module Series (largestProduct) where
 
+largestProduct :: Int -> String -> Maybe Integer
 largestProduct = undefined

--- a/exercises/linked-list/HINTS.md
+++ b/exercises/linked-list/HINTS.md
@@ -9,5 +9,6 @@ and implement the following functions:
 - `unshift`
 - `shift`
 
-You will find the type signatures already in place, but it is up to you
-to define the functions.
+You will find a dummy data declaration and type signatures already in place,
+but it is up to you to define the functions and create a meaningful data type,
+newtype or type synonym.

--- a/exercises/linked-list/src/Deque.hs
+++ b/exercises/linked-list/src/Deque.hs
@@ -1,5 +1,7 @@
 module Deque (Deque, mkDeque, pop, push, shift, unshift) where
 
+data Deque a = Dummy
+
 mkDeque :: IO (Deque a)
 mkDeque = undefined
 

--- a/exercises/matrix/HINTS.md
+++ b/exercises/matrix/HINTS.md
@@ -14,8 +14,9 @@ with `Eq` and `Show` instances, and implement the following functions:
 - `shape`
 - `transpose`
 
-You will find the type signatures already in place, but it is up to you
-to define the functions.
+You will find a dummy data declaration and type signatures already in place,
+but it is up to you to define the functions and create a meaningful data type,
+newtype or type synonym.
 
 No validation of input is required. Let it fail if the matrix is not
 rectangular, invalid chars are encountered, etc.

--- a/exercises/matrix/src/Matrix.hs
+++ b/exercises/matrix/src/Matrix.hs
@@ -14,6 +14,8 @@ module Matrix
 
 import Data.Vector (Vector)
 
+data Matrix a = Dummy deriving (Eq, Show)
+
 cols :: Matrix a -> Int
 cols = undefined
 

--- a/exercises/meetup/.meta/DONT-TEST-STUB
+++ b/exercises/meetup/.meta/DONT-TEST-STUB
@@ -1,0 +1,2 @@
+Can't build because the parameters of meetupDay are unused
+Would also have to export all the individual days of the week in stub; let students figure that out.

--- a/exercises/meetup/HINTS.md
+++ b/exercises/meetup/HINTS.md
@@ -3,5 +3,6 @@
 To complete this exercise, you need to create the data types `Weekday`
 and `Schedule`, and implement the function `meetupDay`.
 
-You will find the type signature for `meetupDay` already in place,
-but it is up to you to define the function.
+You will find the type signature for `meetupDay` and dummy data declarations
+already in place, but it is up to you to define the function and create
+meaningful data types, newtypes or type synonyms.

--- a/exercises/meetup/src/Meetup.hs
+++ b/exercises/meetup/src/Meetup.hs
@@ -2,5 +2,8 @@ module Meetup (Weekday(..), Schedule(..), meetupDay) where
 
 import Data.Time.Calendar (Day)
 
+data Schedule = Dummy
+data Weekday = Dummy2
+
 meetupDay :: Schedule -> Weekday -> Integer -> Int -> Day
 meetupDay schedule weekday year month = undefined

--- a/exercises/pythagorean-triplet/.meta/DONT-TEST-STUB
+++ b/exercises/pythagorean-triplet/.meta/DONT-TEST-STUB
@@ -1,0 +1,2 @@
+No function signatures, since we give students the freedom to define mkTriplet how they want
+But this means we can't make sure that the result of `mkTriplet` is `Eq`

--- a/exercises/robot-name/HINTS.md
+++ b/exercises/robot-name/HINTS.md
@@ -7,5 +7,6 @@ as a mutable variable, and implement the following functions:
 - `resetName`
 - `robotName`
 
-You will find the type signatures already in place, but it is up to you
-to define the functions.
+You will find a dummy data declaration and type signatures already in place,
+but it is up to you to define the functions and create a meaningful data type,
+newtype or type synonym.

--- a/exercises/robot-name/src/Robot.hs
+++ b/exercises/robot-name/src/Robot.hs
@@ -1,5 +1,7 @@
 module Robot (Robot, mkRobot, resetName, robotName) where
 
+data Robot = Dummy
+
 mkRobot :: IO Robot
 mkRobot = undefined
 

--- a/exercises/robot-simulator/HINTS.md
+++ b/exercises/robot-simulator/HINTS.md
@@ -10,5 +10,6 @@ and implement the following functions:
 - `turnLeft`
 - `turnRight`
 
-You will find the type signatures already in place, but it is up to you
-to define the functions.
+You will find a dummy data declaration and type signatures already in place,
+but it is up to you to define the functions and create a meaningful data type,
+newtype or type synonym.

--- a/exercises/robot-simulator/src/Robot.hs
+++ b/exercises/robot-simulator/src/Robot.hs
@@ -14,6 +14,8 @@ data Bearing = North
              | West
              deriving (Eq, Show)
 
+data Robot = Dummy
+
 bearing :: Robot -> Bearing
 bearing = undefined
 

--- a/exercises/secret-handshake/.meta/DONT-TEST-STUB
+++ b/exercises/secret-handshake/.meta/DONT-TEST-STUB
@@ -1,0 +1,1 @@
+No signature, so students can figure out accepting strings and ints.

--- a/exercises/simple-linked-list/HINTS.md
+++ b/exercises/simple-linked-list/HINTS.md
@@ -12,5 +12,6 @@ and implement the following functions:
 - `reverseLinkedList`
 - `toList`
 
-You will find the type signatures already in place, but it is up to you
-to define the functions.
+You will find a dummy data declaration and type signatures already in place,
+but it is up to you to define the functions and create a meaningful data type,
+newtype or type synonym.

--- a/exercises/simple-linked-list/src/LinkedList.hs
+++ b/exercises/simple-linked-list/src/LinkedList.hs
@@ -10,6 +10,8 @@ module LinkedList
     , toList
     ) where
 
+data LinkedList a = Dummy
+
 datum :: LinkedList a -> a
 datum = undefined
 

--- a/exercises/space-age/.meta/DONT-TEST-STUB
+++ b/exercises/space-age/.meta/DONT-TEST-STUB
@@ -1,0 +1,1 @@
+We would have to export all the planets in the stub; let students figure that out.

--- a/exercises/sublist/HINTS.md
+++ b/exercises/sublist/HINTS.md
@@ -1,4 +1,3 @@
 ## Hints
 
-To complete this exercise, you need to create the data type `Sublist`,
-with `Eq` and `Show` instances, and implement the `sublist` function.
+To complete this exercise, you need to implement the `sublist` function.

--- a/exercises/sublist/src/Sublist.hs
+++ b/exercises/sublist/src/Sublist.hs
@@ -1,3 +1,6 @@
 module Sublist (Sublist(..), sublist) where
 
+data Sublist = Equal | Sublist | Superlist | Unequal deriving (Eq, Show)
+
+sublist :: [a] -> [a] -> Sublist
 sublist = undefined

--- a/exercises/zipper/src/Zipper.hs
+++ b/exercises/zipper/src/Zipper.hs
@@ -16,6 +16,8 @@ data BinTree a = BT { btValue :: a
                     , btRight :: Maybe (BinTree a)
                     } deriving (Eq, Show)
 
+data Zipper a = Dummy deriving (Eq, Show)
+
 fromTree :: BinTree a -> Zipper a
 fromTree = undefined
 


### PR DESCRIPTION
Closes #421 

Now all stubs work with `stack build` in Travis, and all stubs except for a few exceptions work with `stack test --no-run-tests`, which compiles with the tests.

We use the .meta directory of https://github.com/exercism/trackler/pull/4 to store a DONT-TEST-STUB marker. This entire directory is not served to students.

---

This PR makes the assumption: **We want all the stubs to build**.

We can relax this assumption, and not even run `stack build` on selected stubs, by adding a `.meta/DONT-BUILD-STUB` file, if we desire. If you believe any change in this PR was made to make the stub build but should not have been made, please state the case, and we could add `.meta/DONT-BUILD-STUB`.

This PR makes the acknowledgement that it would be **ideal** if we can get all the stubs to run the first test and then fail. It then also acknowleges that we couldn't get all stubs to meet this goal at once (in fact, there are some stubs for which we might never want this goal to be met?!), but lets us track how close/far we are from this goal by inspecting how many `DONT-TEST-STUB` files we have.