### PR TITLE
grade-school: Add signatures to stub so it runs tests

### DIFF
--- a/exercises/grade-school/.meta/DONT-TEST-STUB
+++ b/exercises/grade-school/.meta/DONT-TEST-STUB
@@ -1,2 +1,0 @@
-No type signatures on functions (TODO: Should we have them?),
-and this makes it impossible to ensure that the result of `grade` is `Eq`.

--- a/exercises/grade-school/HINTS.md
+++ b/exercises/grade-school/HINTS.md
@@ -8,6 +8,6 @@ and implement the following functions:
 - `grade`
 - `sorted`
 
-You will find a dummy data declaration already in place, but it is up to you to
-define the functions and create a meaningful data type, newtype or type
-synonym.
+You will find a dummy data declaration and type signatures already in
+place, but it is up to you to define the functions and create a meaningful
+data type, newtype or type synonym.

--- a/exercises/grade-school/src/School.hs
+++ b/exercises/grade-school/src/School.hs
@@ -2,10 +2,14 @@ module School (School, add, empty, grade, sorted) where
 
 data School = Dummy
 
-add = undefined
+add :: Int -> String -> School -> School
+add gradeNum student school = undefined
 
+empty :: School
 empty = undefined
 
-grade = undefined
+grade :: Int -> School -> [String]
+grade gradeNum school = undefined
 
-sorted = undefined
+sorted :: School -> [(Int, [String])]
+sorted school = undefined


### PR DESCRIPTION
Lingering work from #421 and #464.

~~It seems acceptable to define the `Grade` and `Student` type synonyms in
the stub, so that the expected return types of the functions will all be
self-explanatory.~~

~~The alternative is, of course, not to define them, and replace all
instances of `Grade` with `Int` and `Student` with `String`, and let the
students figure it out on their own.~~

Although the example solution defines `Grade` and `Student` type
synonyms, we generally leave the definition of these type synonyms to
individual students, so the type signatures provided will just have
`Int` and `String`.

---

What say y'all? Should we define `Grade` and `Student`, or let the students do it? Do we have a precedent? I will say the only other `type` we ever define in a stub is `type Coord = (Int, Int)` in `go-counting`. So I could be convinced to leave this one out.