### PR TITLE
stubs: Substitute undefined by error message

### DIFF
--- a/exercises/accumulate/src/Accumulate.hs
+++ b/exercises/accumulate/src/Accumulate.hs
@@ -1,4 +1,4 @@
 module Accumulate (accumulate) where
 
 accumulate :: (a -> b) -> [a] -> [b]
-accumulate = undefined
+accumulate = error "You need to implement this function."

--- a/exercises/all-your-base/src/Base.hs
+++ b/exercises/all-your-base/src/Base.hs
@@ -1,4 +1,4 @@
 module Base (rebase) where
 
 rebase :: Integral a => a -> a -> [a] -> Maybe [a]
-rebase inputBase outputBase inputDigits = undefined
+rebase inputBase outputBase inputDigits = error "You need to implement this function."

--- a/exercises/allergies/src/Allergies.hs
+++ b/exercises/allergies/src/Allergies.hs
@@ -11,7 +11,7 @@ data Allergen = Eggs
               deriving (Eq)
 
 allergies :: Int -> [Allergen]
-allergies = undefined
+allergies = error "You need to implement this function."
 
 isAllergicTo :: Allergen -> Int -> Bool
-isAllergicTo = undefined
+isAllergicTo = error "You need to implement this function."

--- a/exercises/alphametics/src/Alphametics.hs
+++ b/exercises/alphametics/src/Alphametics.hs
@@ -1,4 +1,4 @@
 module Alphametics (solve) where
 
 solve :: String -> Maybe [(Char, Int)]
-solve puzzle = undefined
+solve puzzle = error "You need to implement this function."

--- a/exercises/anagram/src/Anagram.hs
+++ b/exercises/anagram/src/Anagram.hs
@@ -1,4 +1,4 @@
 module Anagram (anagramsFor) where
 
 anagramsFor :: String -> [String] -> [String]
-anagramsFor = undefined
+anagramsFor = error "You need to implement this function."

--- a/exercises/atbash-cipher/src/Atbash.hs
+++ b/exercises/atbash-cipher/src/Atbash.hs
@@ -1,7 +1,7 @@
 module Atbash (decode, encode) where
 
 decode :: String -> String
-decode = undefined
+decode = error "You need to implement this function."
 
 encode :: String -> String
-encode = undefined
+encode = error "You need to implement this function."

--- a/exercises/bank-account/src/BankAccount.hs
+++ b/exercises/bank-account/src/BankAccount.hs
@@ -9,13 +9,13 @@ module BankAccount
 data BankAccount = Dummy
 
 closeAccount :: BankAccount -> IO ()
-closeAccount = undefined
+closeAccount = error "You need to implement this function."
 
 getBalance :: BankAccount -> IO (Maybe Integer)
-getBalance = undefined
+getBalance = error "You need to implement this function."
 
 incrementBalance :: BankAccount -> Integer -> IO (Maybe Integer)
-incrementBalance = undefined
+incrementBalance = error "You need to implement this function."
 
 openAccount :: IO BankAccount
-openAccount = undefined
+openAccount = error "You need to implement this function."

--- a/exercises/binary-search-tree/src/BST.hs
+++ b/exercises/binary-search-tree/src/BST.hs
@@ -13,25 +13,25 @@ module BST
 data BST a = Dummy deriving (Eq, Show)
 
 bstLeft :: BST a -> Maybe (BST a)
-bstLeft = undefined
+bstLeft = error "You need to implement this function."
 
 bstRight :: BST a -> Maybe (BST a)
-bstRight = undefined
+bstRight = error "You need to implement this function."
 
 bstValue :: BST a -> Maybe a
-bstValue = undefined
+bstValue = error "You need to implement this function."
 
 empty :: BST a
-empty = undefined
+empty = error "You need to implement this function."
 
 fromList :: Ord a => [a] -> BST a
-fromList = undefined
+fromList = error "You need to implement this function."
 
 insert :: Ord a => a -> BST a -> BST a
-insert = undefined
+insert = error "You need to implement this function."
 
 singleton :: a -> BST a
-singleton = undefined
+singleton = error "You need to implement this function."
 
 toList :: BST a -> [a]
-toList = undefined
+toList = error "You need to implement this function."

--- a/exercises/binary/src/Binary.hs
+++ b/exercises/binary/src/Binary.hs
@@ -1,3 +1,3 @@
 module Binary (toDecimal) where
 
-toDecimal = undefined
+toDecimal = error "You need to implement this function."

--- a/exercises/bob/src/Bob.hs
+++ b/exercises/bob/src/Bob.hs
@@ -1,4 +1,4 @@
 module Bob (responseFor) where
 
 responseFor :: String -> String
-responseFor = undefined
+responseFor = error "You need to implement this function."

--- a/exercises/bowling/src/Bowling.hs
+++ b/exercises/bowling/src/Bowling.hs
@@ -5,5 +5,5 @@ data BowlingError = IncompleteGame
   deriving (Eq, Show)
 
 score :: [Int] -> Either BowlingError Int
-score = undefined
+score = error "You need to implement this function."
 

--- a/exercises/change/src/Change.hs
+++ b/exercises/change/src/Change.hs
@@ -1,4 +1,4 @@
 module Change (findFewestCoins) where
 
 findFewestCoins :: Integer -> [Integer] -> Maybe [Integer]
-findFewestCoins target coins = undefined
+findFewestCoins target coins = error "You need to implement this function."

--- a/exercises/clock/src/Clock.hs
+++ b/exercises/clock/src/Clock.hs
@@ -3,13 +3,13 @@ module Clock (clockHour, clockMin, fromHourMin, toString) where
 data Clock = Dummy
 
 clockHour :: Clock -> Int
-clockHour = undefined
+clockHour = error "You need to implement this function."
 
 clockMin :: Clock -> Int
-clockMin = undefined
+clockMin = error "You need to implement this function."
 
 fromHourMin :: Int -> Int -> Clock
-fromHourMin = undefined
+fromHourMin = error "You need to implement this function."
 
 toString :: Clock -> String
-toString = undefined
+toString = error "You need to implement this function."

--- a/exercises/connect/src/Connect.hs
+++ b/exercises/connect/src/Connect.hs
@@ -3,4 +3,4 @@ module Connect (Mark(..), winner) where
 data Mark = Cross | Nought deriving (Eq, Show)
 
 winner :: [String] -> Maybe Mark
-winner = undefined
+winner = error "You need to implement this function."

--- a/exercises/crypto-square/src/CryptoSquare.hs
+++ b/exercises/crypto-square/src/CryptoSquare.hs
@@ -1,4 +1,4 @@
 module CryptoSquare (encode) where
 
 encode :: String -> String
-encode = undefined
+encode = error "You need to implement this function."

--- a/exercises/custom-set/src/CustomSet.hs
+++ b/exercises/custom-set/src/CustomSet.hs
@@ -19,40 +19,40 @@ import Prelude hiding (null)
 data CustomSet a = Dummy deriving (Eq, Show)
 
 delete :: a -> CustomSet a -> CustomSet a
-delete = undefined
+delete = error "You need to implement this function."
 
 difference :: CustomSet a -> CustomSet a -> CustomSet a
-difference = undefined
+difference = error "You need to implement this function."
 
 empty :: CustomSet a
-empty = undefined
+empty = error "You need to implement this function."
 
 fromList :: [a] -> CustomSet a
-fromList = undefined
+fromList = error "You need to implement this function."
 
 insert :: a -> CustomSet a -> CustomSet a
-insert = undefined
+insert = error "You need to implement this function."
 
 intersection :: CustomSet a -> CustomSet a -> CustomSet a
-intersection = undefined
+intersection = error "You need to implement this function."
 
 isDisjointFrom :: CustomSet a -> CustomSet a -> Bool
-isDisjointFrom = undefined
+isDisjointFrom = error "You need to implement this function."
 
 isSubsetOf :: CustomSet a -> CustomSet a -> Bool
-isSubsetOf = undefined
+isSubsetOf = error "You need to implement this function."
 
 member :: a -> CustomSet a -> Bool
-member = undefined
+member = error "You need to implement this function."
 
 null :: CustomSet a -> Bool
-null = undefined
+null = error "You need to implement this function."
 
 size :: CustomSet a -> Int
-size = undefined
+size = error "You need to implement this function."
 
 toList :: CustomSet a -> [a]
-toList = undefined
+toList = error "You need to implement this function."
 
 union :: CustomSet a -> CustomSet a -> CustomSet a
-union = undefined
+union = error "You need to implement this function."

--- a/exercises/difference-of-squares/src/Squares.hs
+++ b/exercises/difference-of-squares/src/Squares.hs
@@ -1,10 +1,10 @@
 module Squares (difference, squareOfSums, sumOfSquares) where
 
 difference :: Integral a => a -> a
-difference = undefined
+difference = error "You need to implement this function."
 
 squareOfSums :: Integral a => a -> a
-squareOfSums = undefined
+squareOfSums = error "You need to implement this function."
 
 sumOfSquares :: Integral a => a -> a
-sumOfSquares = undefined
+sumOfSquares = error "You need to implement this function."

--- a/exercises/dominoes/src/Dominoes.hs
+++ b/exercises/dominoes/src/Dominoes.hs
@@ -1,4 +1,4 @@
 module Dominoes (chain) where
 
 chain :: [(Int, Int)] -> Maybe [(Int, Int)]
-chain dominoes = undefined
+chain dominoes = error "You need to implement this function."

--- a/exercises/etl/src/ETL.hs
+++ b/exercises/etl/src/ETL.hs
@@ -3,4 +3,4 @@ module ETL (transform) where
 import Data.Map (Map)
 
 transform :: Map a String -> Map Char a
-transform = undefined
+transform = error "You need to implement this function."

--- a/exercises/forth/src/Forth.hs
+++ b/exercises/forth/src/Forth.hs
@@ -20,10 +20,10 @@ data ForthError
 data ForthState = Dummy
 
 empty :: ForthState
-empty = undefined
+empty = error "You need to implement this function."
 
 evalText :: Text -> ForthState -> Either ForthError ForthState
-evalText = undefined
+evalText = error "You need to implement this function."
 
 toList :: ForthState -> [Int]
-toList = undefined
+toList = error "You need to implement this function."

--- a/exercises/gigasecond/src/Gigasecond.hs
+++ b/exercises/gigasecond/src/Gigasecond.hs
@@ -3,4 +3,4 @@ module Gigasecond (fromDay) where
 import Data.Time.Clock (UTCTime)
 
 fromDay :: UTCTime -> UTCTime
-fromDay = undefined
+fromDay = error "You need to implement this function."

--- a/exercises/go-counting/src/Counting.hs
+++ b/exercises/go-counting/src/Counting.hs
@@ -10,7 +10,7 @@ data Color = Black | White deriving (Eq, Ord, Show)
 type Coord = (Int, Int)
 
 territories :: [String] -> [(Set Coord, Maybe Color)]
-territories = undefined
+territories = error "You need to implement this function."
 
 territoryFor :: [String] -> Coord -> Maybe (Set Coord, Maybe Color)
-territoryFor = undefined
+territoryFor = error "You need to implement this function."

--- a/exercises/grade-school/src/School.hs
+++ b/exercises/grade-school/src/School.hs
@@ -3,13 +3,13 @@ module School (School, add, empty, grade, sorted) where
 data School = Dummy
 
 add :: Int -> String -> School -> School
-add gradeNum student school = undefined
+add gradeNum student school = error "You need to implement this function."
 
 empty :: School
-empty = undefined
+empty = error "You need to implement this function."
 
 grade :: Int -> School -> [String]
-grade gradeNum school = undefined
+grade gradeNum school = error "You need to implement this function."
 
 sorted :: School -> [(Int, [String])]
-sorted school = undefined
+sorted school = error "You need to implement this function."

--- a/exercises/grains/src/Grains.hs
+++ b/exercises/grains/src/Grains.hs
@@ -1,7 +1,7 @@
 module Grains (square, total) where
 
 square :: Integer -> Maybe Integer
-square n = undefined
+square n = error "You need to implement this function."
 
 total :: Integer
-total = undefined
+total = error "You need to implement this function."

--- a/exercises/hamming/src/Hamming.hs
+++ b/exercises/hamming/src/Hamming.hs
@@ -1,3 +1,3 @@
 module Hamming (distance) where
 
-distance = undefined
+distance = error "You need to implement this function."

--- a/exercises/hexadecimal/src/Hexadecimal.hs
+++ b/exercises/hexadecimal/src/Hexadecimal.hs
@@ -1,3 +1,3 @@
 module Hexadecimal (hexToInt) where
 
-hexToInt = undefined
+hexToInt = error "You need to implement this function."

--- a/exercises/kindergarten-garden/src/Garden.hs
+++ b/exercises/kindergarten-garden/src/Garden.hs
@@ -14,10 +14,10 @@ data Plant = Clover
            deriving (Eq, Show)
 
 defaultGarden :: String -> Map String [Plant]
-defaultGarden = undefined
+defaultGarden = error "You need to implement this function."
 
 garden :: [String] -> String -> Map String [Plant]
-garden = undefined
+garden = error "You need to implement this function."
 
 lookupPlants :: String -> Map String [Plant] -> [Plant]
-lookupPlants = undefined
+lookupPlants = error "You need to implement this function."

--- a/exercises/largest-series-product/src/Series.hs
+++ b/exercises/largest-series-product/src/Series.hs
@@ -1,4 +1,4 @@
 module Series (largestProduct) where
 
 largestProduct :: Int -> String -> Maybe Integer
-largestProduct = undefined
+largestProduct = error "You need to implement this function."

--- a/exercises/leap/src/LeapYear.hs
+++ b/exercises/leap/src/LeapYear.hs
@@ -1,4 +1,4 @@
 module LeapYear (isLeapYear) where
 
 isLeapYear :: Integer -> Bool
-isLeapYear year = undefined
+isLeapYear year = error "You need to implement this function."

--- a/exercises/lens-person/src/Person.hs
+++ b/exercises/lens-person/src/Person.hs
@@ -31,13 +31,13 @@ data Address = Address { _street      :: String
                        }
 
 bornStreet :: Born -> String
-bornStreet = undefined
+bornStreet = error "You need to implement this function."
 
 setCurrentStreet :: String -> Person -> Person
-setCurrentStreet = undefined
+setCurrentStreet = error "You need to implement this function."
 
 setBirthMonth :: Int -> Person -> Person
-setBirthMonth = undefined
+setBirthMonth = error "You need to implement this function."
 
 renameStreets :: (String -> String) -> Person -> Person
-renameStreets = undefined
+renameStreets = error "You need to implement this function."

--- a/exercises/linked-list/src/Deque.hs
+++ b/exercises/linked-list/src/Deque.hs
@@ -3,16 +3,16 @@ module Deque (Deque, mkDeque, pop, push, shift, unshift) where
 data Deque a = Dummy
 
 mkDeque :: IO (Deque a)
-mkDeque = undefined
+mkDeque = error "You need to implement this function."
 
 pop :: Deque a -> IO (Maybe a)
-pop = undefined
+pop = error "You need to implement this function."
 
 push :: Deque a -> a -> IO ()
-push = undefined
+push = error "You need to implement this function."
 
 unshift :: Deque a -> a -> IO ()
-unshift = undefined
+unshift = error "You need to implement this function."
 
 shift :: Deque a -> IO (Maybe a)
-shift = undefined
+shift = error "You need to implement this function."

--- a/exercises/list-ops/src/ListOps.hs
+++ b/exercises/list-ops/src/ListOps.hs
@@ -13,25 +13,25 @@ import Prelude hiding
   ( length, reverse, map, filter, foldr, (++), concat )
 
 foldl' :: (b -> a -> b) -> b -> [a] -> b
-foldl' = undefined
+foldl' = error "You need to implement this function."
 
 foldr :: (a -> b -> b) -> b -> [a] -> b
-foldr = undefined
+foldr = error "You need to implement this function."
 
 length :: [a] -> Int
-length = undefined
+length = error "You need to implement this function."
 
 reverse :: [a] -> [a]
-reverse = undefined
+reverse = error "You need to implement this function."
 
 map :: (a -> b) -> [a] -> [b]
-map = undefined
+map = error "You need to implement this function."
 
 filter :: (a -> Bool) -> [a] -> [a]
-filter = undefined
+filter = error "You need to implement this function."
 
 (++) :: [a] -> [a] -> [a]
-xs ++ ys = undefined
+xs ++ ys = error "You need to implement this function."
 
 concat :: [[a]] -> [a]
-concat = undefined
+concat = error "You need to implement this function."

--- a/exercises/luhn/src/Luhn.hs
+++ b/exercises/luhn/src/Luhn.hs
@@ -1,11 +1,11 @@
 module Luhn (addends, checkDigit, checksum, create, isValid) where
 
-addends = undefined
+addends = error "You need to implement this function."
 
-checkDigit = undefined
+checkDigit = error "You need to implement this function."
 
-checksum = undefined
+checksum = error "You need to implement this function."
 
-create = undefined
+create = error "You need to implement this function."
 
-isValid = undefined
+isValid = error "You need to implement this function."

--- a/exercises/matrix/src/Matrix.hs
+++ b/exercises/matrix/src/Matrix.hs
@@ -17,31 +17,31 @@ import Data.Vector (Vector)
 data Matrix a = Dummy deriving (Eq, Show)
 
 cols :: Matrix a -> Int
-cols = undefined
+cols = error "You need to implement this function."
 
 column :: Int -> Matrix a -> Vector a
-column = undefined
+column = error "You need to implement this function."
 
 flatten :: Matrix a -> Vector a
-flatten = undefined
+flatten = error "You need to implement this function."
 
 fromList :: [[a]] -> Matrix a
-fromList = undefined
+fromList = error "You need to implement this function."
 
 fromString :: Read a => String -> Matrix a
-fromString = undefined
+fromString = error "You need to implement this function."
 
 reshape :: (Int, Int) -> Matrix a -> Matrix a
-reshape = undefined
+reshape = error "You need to implement this function."
 
 row :: Int -> Matrix a -> Vector a
-row = undefined
+row = error "You need to implement this function."
 
 rows :: Matrix a -> Int
-rows = undefined
+rows = error "You need to implement this function."
 
 shape :: Matrix a -> (Int, Int)
-shape = undefined
+shape = error "You need to implement this function."
 
 transpose :: Matrix a -> Matrix a
-transpose = undefined
+transpose = error "You need to implement this function."

--- a/exercises/meetup/src/Meetup.hs
+++ b/exercises/meetup/src/Meetup.hs
@@ -18,4 +18,4 @@ data Schedule = First
               | Teenth
 
 meetupDay :: Schedule -> Weekday -> Integer -> Int -> Day
-meetupDay schedule weekday year month = undefined
+meetupDay schedule weekday year month = error "You need to implement this function."

--- a/exercises/minesweeper/src/Minesweeper.hs
+++ b/exercises/minesweeper/src/Minesweeper.hs
@@ -1,4 +1,4 @@
 module Minesweeper (annotate) where
 
 annotate :: [String] -> [String]
-annotate = undefined
+annotate = error "You need to implement this function."

--- a/exercises/nth-prime/src/Prime.hs
+++ b/exercises/nth-prime/src/Prime.hs
@@ -1,3 +1,3 @@
 module Prime (nth) where
 
-nth = undefined
+nth = error "You need to implement this function."

--- a/exercises/nucleotide-count/src/DNA.hs
+++ b/exercises/nucleotide-count/src/DNA.hs
@@ -3,7 +3,7 @@ module DNA (count, nucleotideCounts) where
 import Data.Map (Map)
 
 count :: Char -> String -> Either String Int
-count = undefined
+count = error "You need to implement this function."
 
 nucleotideCounts :: String -> Either String (Map Char Int)
-nucleotideCounts = undefined
+nucleotideCounts = error "You need to implement this function."

--- a/exercises/ocr-numbers/src/OCR.hs
+++ b/exercises/ocr-numbers/src/OCR.hs
@@ -1,4 +1,4 @@
 module OCR (convert) where
 
 convert :: String -> String
-convert = undefined
+convert = error "You need to implement this function."

--- a/exercises/octal/src/Octal.hs
+++ b/exercises/octal/src/Octal.hs
@@ -1,5 +1,5 @@
 module Octal (readOct, showOct) where
 
-readOct = undefined
+readOct = error "You need to implement this function."
 
-showOct = undefined
+showOct = error "You need to implement this function."

--- a/exercises/palindrome-products/src/Palindromes.hs
+++ b/exercises/palindrome-products/src/Palindromes.hs
@@ -1,7 +1,7 @@
 module Palindromes (largestPalindrome, smallestPalindrome) where
 
 largestPalindrome :: Integer -> Integer -> (Integer, [(Integer, Integer)])
-largestPalindrome minFactor maxFactor = undefined
+largestPalindrome minFactor maxFactor = error "You need to implement this function."
 
 smallestPalindrome :: Integer -> Integer -> (Integer, [(Integer, Integer)])
-smallestPalindrome minFactor maxFactor = undefined
+smallestPalindrome minFactor maxFactor = error "You need to implement this function."

--- a/exercises/parallel-letter-frequency/src/Frequency.hs
+++ b/exercises/parallel-letter-frequency/src/Frequency.hs
@@ -4,4 +4,4 @@ import Data.Map  (Map)
 import Data.Text (Text)
 
 frequency :: Int -> [Text] -> Map Char Int
-frequency nWorkers texts = undefined
+frequency nWorkers texts = error "You need to implement this function."

--- a/exercises/pascals-triangle/src/Triangle.hs
+++ b/exercises/pascals-triangle/src/Triangle.hs
@@ -1,4 +1,4 @@
 module Triangle (rows) where
 
 rows :: Int -> [[Integer]]
-rows = undefined
+rows = error "You need to implement this function."

--- a/exercises/phone-number/src/Phone.hs
+++ b/exercises/phone-number/src/Phone.hs
@@ -1,10 +1,10 @@
 module Phone (areaCode, number, prettyPrint) where
 
 areaCode :: String -> Maybe String
-areaCode = undefined
+areaCode = error "You need to implement this function."
 
 number :: String -> Maybe String
-number = undefined
+number = error "You need to implement this function."
 
 prettyPrint :: String -> Maybe String
-prettyPrint = undefined
+prettyPrint = error "You need to implement this function."

--- a/exercises/pig-latin/src/PigLatin.hs
+++ b/exercises/pig-latin/src/PigLatin.hs
@@ -1,4 +1,4 @@
 module PigLatin (translate) where
 
 translate :: String -> String
-translate = undefined
+translate = error "You need to implement this function."

--- a/exercises/pov/src/POV.hs
+++ b/exercises/pov/src/POV.hs
@@ -3,7 +3,7 @@ module POV (fromPOV, tracePathBetween) where
 import Data.Tree (Tree)
 
 fromPOV :: Eq a => a -> Tree a -> Maybe (Tree a)
-fromPOV = undefined
+fromPOV = error "You need to implement this function."
 
 tracePathBetween :: Eq a => a -> a -> Tree a -> Maybe [a]
-tracePathBetween = undefined
+tracePathBetween = error "You need to implement this function."

--- a/exercises/prime-factors/src/PrimeFactors.hs
+++ b/exercises/prime-factors/src/PrimeFactors.hs
@@ -1,4 +1,4 @@
 module PrimeFactors (primeFactors) where
 
 primeFactors :: Integer -> [Integer]
-primeFactors = undefined
+primeFactors = error "You need to implement this function."

--- a/exercises/pythagorean-triplet/src/Triplet.hs
+++ b/exercises/pythagorean-triplet/src/Triplet.hs
@@ -1,7 +1,7 @@
 module Triplet (isPythagorean, mkTriplet, pythagoreanTriplets) where
 
-isPythagorean = undefined
+isPythagorean = error "You need to implement this function."
 
-mkTriplet = undefined
+mkTriplet = error "You need to implement this function."
 
-pythagoreanTriplets = undefined
+pythagoreanTriplets = error "You need to implement this function."

--- a/exercises/queen-attack/src/Queens.hs
+++ b/exercises/queen-attack/src/Queens.hs
@@ -1,7 +1,7 @@
 module Queens (boardString, canAttack) where
 
 boardString :: Maybe (Int, Int) -> Maybe (Int, Int) -> String
-boardString white black = undefined
+boardString white black = error "You need to implement this function."
 
 canAttack :: (Int, Int) -> (Int, Int) -> Bool
-canAttack = undefined
+canAttack = error "You need to implement this function."

--- a/exercises/raindrops/src/Raindrops.hs
+++ b/exercises/raindrops/src/Raindrops.hs
@@ -1,3 +1,3 @@
 module Raindrops (convert) where
 
-convert = undefined
+convert = error "You need to implement this function."

--- a/exercises/rna-transcription/src/DNA.hs
+++ b/exercises/rna-transcription/src/DNA.hs
@@ -1,4 +1,4 @@
 module DNA (toRNA) where
 
 toRNA :: String -> Maybe String
-toRNA = undefined
+toRNA = error "You need to implement this function."

--- a/exercises/robot-name/src/Robot.hs
+++ b/exercises/robot-name/src/Robot.hs
@@ -3,10 +3,10 @@ module Robot (Robot, mkRobot, resetName, robotName) where
 data Robot = Dummy
 
 mkRobot :: IO Robot
-mkRobot = undefined
+mkRobot = error "You need to implement this function."
 
 resetName :: Robot -> IO ()
-resetName = undefined
+resetName = error "You need to implement this function."
 
 robotName :: Robot -> IO String
-robotName = undefined
+robotName = error "You need to implement this function."

--- a/exercises/robot-simulator/src/Robot.hs
+++ b/exercises/robot-simulator/src/Robot.hs
@@ -17,19 +17,19 @@ data Bearing = North
 data Robot = Dummy
 
 bearing :: Robot -> Bearing
-bearing = undefined
+bearing = error "You need to implement this function."
 
 coordinates :: Robot -> (Integer, Integer)
-coordinates = undefined
+coordinates = error "You need to implement this function."
 
 mkRobot :: Bearing -> (Integer, Integer) -> Robot
-mkRobot = undefined
+mkRobot = error "You need to implement this function."
 
 simulate :: Robot -> String -> Robot
-simulate = undefined
+simulate = error "You need to implement this function."
 
 turnLeft :: Bearing -> Bearing
-turnLeft = undefined
+turnLeft = error "You need to implement this function."
 
 turnRight :: Bearing -> Bearing
-turnRight = undefined
+turnRight = error "You need to implement this function."

--- a/exercises/roman-numerals/src/Roman.hs
+++ b/exercises/roman-numerals/src/Roman.hs
@@ -1,3 +1,3 @@
 module Roman (numerals) where
 
-numerals = undefined
+numerals = error "You need to implement this function."

--- a/exercises/run-length-encoding/src/RunLength.hs
+++ b/exercises/run-length-encoding/src/RunLength.hs
@@ -1,7 +1,7 @@
 module RunLength (decode, encode) where
 
 decode :: String -> String
-decode = undefined
+decode = error "You need to implement this function."
 
 encode :: String -> String
-encode = undefined
+encode = error "You need to implement this function."

--- a/exercises/saddle-points/src/Matrix.hs
+++ b/exercises/saddle-points/src/Matrix.hs
@@ -2,4 +2,4 @@ module Matrix (saddlePoints) where
 
 import Data.Array (Array)
 
-saddlePoints = undefined
+saddlePoints = error "You need to implement this function."

--- a/exercises/say/src/Say.hs
+++ b/exercises/say/src/Say.hs
@@ -1,3 +1,3 @@
 module Say (inEnglish) where
 
-inEnglish = undefined
+inEnglish = error "You need to implement this function."

--- a/exercises/scrabble-score/src/Scrabble.hs
+++ b/exercises/scrabble-score/src/Scrabble.hs
@@ -1,5 +1,5 @@
 module Scrabble (scoreLetter, scoreWord) where
 
-scoreLetter = undefined
+scoreLetter = error "You need to implement this function."
 
-scoreWord = undefined
+scoreWord = error "You need to implement this function."

--- a/exercises/secret-handshake/src/SecretHandshake.hs
+++ b/exercises/secret-handshake/src/SecretHandshake.hs
@@ -1,3 +1,3 @@
 module SecretHandshake (handshake) where
 
-handshake = undefined
+handshake = error "You need to implement this function."

--- a/exercises/series/src/Series.hs
+++ b/exercises/series/src/Series.hs
@@ -1,4 +1,4 @@
 module Series (slices) where
 
 slices :: Int -> String -> [[Int]]
-slices n xs = undefined
+slices n xs = error "You need to implement this function."

--- a/exercises/sgf-parsing/src/Sgf.hs
+++ b/exercises/sgf-parsing/src/Sgf.hs
@@ -5,4 +5,4 @@ import Data.Text (Text)
 import Data.Tree (Tree)
 
 parseSgf :: Text -> Maybe (Tree (Map Text [Text]))
-parseSgf = undefined
+parseSgf = error "You need to implement this function."

--- a/exercises/sieve/src/Sieve.hs
+++ b/exercises/sieve/src/Sieve.hs
@@ -1,3 +1,3 @@
 module Sieve (primesUpTo) where
 
-primesUpTo = undefined
+primesUpTo = error "You need to implement this function."

--- a/exercises/simple-cipher/src/Cipher.hs
+++ b/exercises/simple-cipher/src/Cipher.hs
@@ -1,10 +1,10 @@
 module Cipher (caesarDecode, caesarEncode, caesarEncodeRandom) where
 
 caesarDecode :: String -> String -> String
-caesarDecode = undefined
+caesarDecode = error "You need to implement this function."
 
 caesarEncode :: String -> String -> String
-caesarEncode = undefined
+caesarEncode = error "You need to implement this function."
 
 caesarEncodeRandom :: String -> IO (String, String)
-caesarEncodeRandom = undefined
+caesarEncodeRandom = error "You need to implement this function."

--- a/exercises/simple-linked-list/src/LinkedList.hs
+++ b/exercises/simple-linked-list/src/LinkedList.hs
@@ -13,25 +13,25 @@ module LinkedList
 data LinkedList a = Dummy
 
 datum :: LinkedList a -> a
-datum = undefined
+datum = error "You need to implement this function."
 
 fromList :: [a] -> LinkedList a
-fromList = undefined
+fromList = error "You need to implement this function."
 
 isNil :: LinkedList a -> Bool
-isNil = undefined
+isNil = error "You need to implement this function."
 
 new :: a -> LinkedList a -> LinkedList a
-new = undefined
+new = error "You need to implement this function."
 
 next :: LinkedList a -> LinkedList a
-next = undefined
+next = error "You need to implement this function."
 
 nil :: LinkedList a
-nil = undefined
+nil = error "You need to implement this function."
 
 reverseLinkedList :: LinkedList a -> LinkedList a
-reverseLinkedList = undefined
+reverseLinkedList = error "You need to implement this function."
 
 toList :: LinkedList a -> [a]
-toList = undefined
+toList = error "You need to implement this function."

--- a/exercises/space-age/src/SpaceAge.hs
+++ b/exercises/space-age/src/SpaceAge.hs
@@ -10,4 +10,4 @@ data Planet = Mercury
             | Neptune
 
 ageOn :: Planet -> Float -> Float
-ageOn planet seconds = undefined
+ageOn planet seconds = error "You need to implement this function."

--- a/exercises/strain/src/Strain.hs
+++ b/exercises/strain/src/Strain.hs
@@ -1,7 +1,7 @@
 module Strain (keep, discard) where
 
 discard :: (a -> Bool) -> [a] -> [a]
-discard = undefined
+discard = error "You need to implement this function."
 
 keep :: (a -> Bool) -> [a] -> [a]
-keep = undefined
+keep = error "You need to implement this function."

--- a/exercises/sublist/src/Sublist.hs
+++ b/exercises/sublist/src/Sublist.hs
@@ -3,4 +3,4 @@ module Sublist (Sublist(..), sublist) where
 data Sublist = Equal | Sublist | Superlist | Unequal deriving (Eq, Show)
 
 sublist :: [a] -> [a] -> Sublist
-sublist = undefined
+sublist = error "You need to implement this function."

--- a/exercises/sum-of-multiples/src/SumOfMultiples.hs
+++ b/exercises/sum-of-multiples/src/SumOfMultiples.hs
@@ -1,3 +1,3 @@
 module SumOfMultiples (sumOfMultiples) where
 
-sumOfMultiples = undefined
+sumOfMultiples = error "You need to implement this function."

--- a/exercises/triangle/src/Triangle.hs
+++ b/exercises/triangle/src/Triangle.hs
@@ -6,4 +6,4 @@ data TriangleType = Equilateral
                   | Illegal
                   deriving (Eq, Show)
 
-triangleType = undefined
+triangleType = error "You need to implement this function."

--- a/exercises/trinary/src/Trinary.hs
+++ b/exercises/trinary/src/Trinary.hs
@@ -1,5 +1,5 @@
 module Trinary (readTri, showTri) where
 
-readTri = undefined
+readTri = error "You need to implement this function."
 
-showTri = undefined
+showTri = error "You need to implement this function."

--- a/exercises/word-count/src/WordCount.hs
+++ b/exercises/word-count/src/WordCount.hs
@@ -1,4 +1,4 @@
 module WordCount (wordCount) where
 
 wordCount :: String -> [(String, Int)]
-wordCount xs = undefined
+wordCount xs = error "You need to implement this function."

--- a/exercises/wordy/src/WordProblem.hs
+++ b/exercises/wordy/src/WordProblem.hs
@@ -1,3 +1,3 @@
 module WordProblem (answer) where
 
-answer = undefined
+answer = error "You need to implement this function."

--- a/exercises/zebra-puzzle/src/ZebraPuzzle.hs
+++ b/exercises/zebra-puzzle/src/ZebraPuzzle.hs
@@ -8,5 +8,5 @@ data Solution = Solution { waterDrinker :: Resident
                          } deriving (Eq, Show)
 
 solve :: Solution
-solve = undefined
+solve = error "You need to implement this function."
 

--- a/exercises/zipper/src/Zipper.hs
+++ b/exercises/zipper/src/Zipper.hs
@@ -19,28 +19,28 @@ data BinTree a = BT { btValue :: a
 data Zipper a = Dummy deriving (Eq, Show)
 
 fromTree :: BinTree a -> Zipper a
-fromTree = undefined
+fromTree = error "You need to implement this function."
 
 toTree :: Zipper a -> BinTree a
-toTree = undefined
+toTree = error "You need to implement this function."
 
 value :: Zipper a -> a
-value = undefined
+value = error "You need to implement this function."
 
 left :: Zipper a -> Maybe (Zipper a)
-left = undefined
+left = error "You need to implement this function."
 
 right :: Zipper a -> Maybe (Zipper a)
-right = undefined
+right = error "You need to implement this function."
 
 up :: Zipper a -> Maybe (Zipper a)
-up = undefined
+up = error "You need to implement this function."
 
 setValue :: a -> Zipper a -> Zipper a
-setValue = undefined
+setValue = error "You need to implement this function."
 
 setLeft :: Maybe (BinTree a) -> Zipper a -> Zipper a
-setLeft = undefined
+setLeft = error "You need to implement this function."
 
 setRight :: Maybe (BinTree a) -> Zipper a -> Zipper a
-setRight = undefined
+setRight = error "You need to implement this function."


### PR DESCRIPTION
In #459, we decided that it would be better to use `error` instead of `undefined` as a placeholder for function definitions, because it gives a descriptive error messages when running the tests.