### PR TITLE
lens-person: Remove lens from example solution

### DIFF
--- a/exercises/lens-person/examples/success-standard/package.yaml
+++ b/exercises/lens-person/examples/success-standard/package.yaml
@@ -8,7 +8,6 @@ library:
   exposed-modules: Person
   source-dirs: src
   dependencies:
-    - lens
 
 tests:
   test:

--- a/exercises/lens-person/examples/success-standard/src/Person.hs
+++ b/exercises/lens-person/examples/success-standard/src/Person.hs
@@ -1,9 +1,10 @@
-{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE Rank2Types #-}
 
 module Person where
 
-import Control.Lens
-import Data.Time.Calendar
+import Control.Applicative (Const(..), getConst)
+import Data.Functor.Identity (Identity(..), runIdentity)
+import Data.Time.Calendar (Day, toGregorian, fromGregorian)
 
 data Person = Person {
       _name    :: Name,
@@ -36,17 +37,44 @@ data Gregorian = Gregorian {
       _day   :: Int
     }
 
-makeLenses ''Person
-makeLenses ''Name
-makeLenses ''Born
-makeLenses ''Address
-makeLenses ''Gregorian
+type Lens s t a b = forall f. Functor f => (a -> f b) -> s -> f t
+type Lens' s a = Lens s s a a
+type Getting s a = (a -> Const a a) -> s -> Const a s
+type Setting s t a b = (a -> Identity b) -> s -> Identity t
 
-gregorianDay :: Iso' Gregorian Day
-gregorianDay = iso toDay fromDay
-  where
-    toDay (Gregorian y m d) = fromGregorian y m d
-    fromDay d' = let (y, m, d) = toGregorian d' in Gregorian y m d
+lens :: (s -> a) -> (s -> b -> t) -> Lens s t a b
+lens sa sbt afb s = fmap (sbt s) (afb (sa s))
+
+view :: Getting s a -> s -> a
+view l = getConst . l Const
+
+over :: Setting s t a b -> (a -> b) -> s -> t
+over l f = runIdentity . l (Identity . f)
+
+set :: Setting s t a b -> b -> s -> t
+set l v = over l (const v)
+
+-- boilerplate lenses:
+
+born :: Lens' Person Born
+born = lens _born (\p b -> p { _born = b })
+
+address :: Lens' Person Address
+address = lens _address (\p a -> p { _address = a })
+
+bornAt :: Lens' Born Address
+bornAt = lens _bornAt (\b a -> b { _bornAt = a })
+
+bornOn :: Lens' Born Day
+bornOn = lens _bornOn (\b d -> b { _bornOn = d })
+
+street :: Lens' Address String
+street = lens _street (\a s -> a { _street = s })
+
+month :: Lens' Day Int
+month = lens getMonth setMonth
+  where getMonth day   = let (_, m, _) = toGregorian day in m
+        setMonth day m = let (y, _, d) = toGregorian day in fromGregorian y m d
 
 bornStreet :: Born -> String
 bornStreet = view (bornAt . street)
@@ -55,7 +83,7 @@ setCurrentStreet :: String -> Person -> Person
 setCurrentStreet = set (address . street)
 
 setBirthMonth :: Int -> Person -> Person
-setBirthMonth = set (born . bornOn . from gregorianDay . month)
+setBirthMonth = set (born . bornOn . month)
 
 renameStreets :: (String -> String) -> Person -> Person
 renameStreets f = over birthStreet f . over currentStreet f

--- a/exercises/lens-person/examples/success-standard/src/Person.hs
+++ b/exercises/lens-person/examples/success-standard/src/Person.hs
@@ -2,8 +2,8 @@
 
 module Person where
 
-import           Control.Lens
-import           Data.Time.Calendar
+import Control.Lens
+import Data.Time.Calendar
 
 data Person = Person {
       _name    :: Name,


### PR DESCRIPTION
Here is a proposal.

`lens` is quite a large library with many dependencies, right? And it is not strictly required to pass the tests of the `lens-person` exercise.

So, what if we were to reduce our dependency footprint by not using `lens` at all?

I'm not sure whether this will actually have a noticeable benefit for us and/or whether using `lens` is actually causing us any problems. Let's see.