### PR TITLE
phone-number: simplify to number only

### DIFF
--- a/exercises/phone-number/examples/success-standard/src/Phone.hs
+++ b/exercises/phone-number/examples/success-standard/src/Phone.hs
@@ -1,28 +1,11 @@
-module Phone (number, areaCode, prettyPrint) where
-import Data.Char (isDigit)
+module Phone (number) where
+import Data.Char (isDigit, isLetter)
 
 number :: String -> Maybe String
 number input
+  | any isLetter input = Nothing
   | len == 10 = Just digits
   | len == 11 && head digits == '1' = Just $ tail digits
   | otherwise = Nothing
   where digits = filter isDigit input
         len = length digits
-
-parts :: String -> Maybe (String, String, String)
-parts input = case number input of
-    Nothing   -> Nothing
-    Just digits -> Just (ac, exchange, subscriber)
-      where
-        (ac, exchangeSubscriber) = splitAt 3 digits
-        (exchange, subscriber) = splitAt 3 exchangeSubscriber
-
-areaCode :: String -> Maybe String
-areaCode input = case parts input of
-  Just (ac, _, _) -> Just ac
-  Nothing         -> Nothing
-
-prettyPrint :: String -> Maybe String
-prettyPrint input = case parts input of
-  Just (ac, exchange, subscriber) -> Just $ "(" ++ ac ++ ") " ++ exchange ++ "-" ++ subscriber
-  Nothing                         -> Nothing

--- a/exercises/phone-number/src/Phone.hs
+++ b/exercises/phone-number/src/Phone.hs
@@ -1,10 +1,4 @@
-module Phone (areaCode, number, prettyPrint) where
-
-areaCode :: String -> Maybe String
-areaCode = error "You need to implement this function."
+module Phone (number) where
 
 number :: String -> Maybe String
 number = error "You need to implement this function."
-
-prettyPrint :: String -> Maybe String
-prettyPrint = error "You need to implement this function."

--- a/exercises/phone-number/test/Tests.hs
+++ b/exercises/phone-number/test/Tests.hs
@@ -4,115 +4,64 @@ import Data.Foldable     (for_)
 import Test.Hspec        (Spec, describe, it, shouldBe)
 import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
 
-import Phone (areaCode, number, prettyPrint)
+import Phone (number)
 
 main :: IO ()
 main = hspecWith defaultConfig {configFastFail = True} specs
 
 specs :: Spec
-specs = describe "phone-number" $ do
-          describe "number"      $ for_ numberCases      $ test number
-          describe "areaCode"    $ for_ areaCodeCases    $ test areaCode
-          describe "prettyPrint" $ for_ prettyPrintCases $ test prettyPrint
+specs = describe "phone-number" $
+          describe "number" $ for_ cases test
   where
-    test f Case{..} = it description $ f input `shouldBe` expected
+    test Case{..} = it description $ number input `shouldBe` expected
 
--- As of 2016-07-27, there was no reference file
--- for the test cases in `exercism/x-common`.
+-- Test cases adapted from `exercism/x-common/phone-number` on 2017-01-31.
 
 data Case = Case { description ::       String
                  , input       ::       String
                  , expected    :: Maybe String
                  }
 
-numberCases :: [Case]
-numberCases =
-    [ Case { description = "cleans number"
+cases :: [Case]
+cases =
+    [ Case { description = "cleans the number"
            , input       = "(123) 456-7890"
            , expected    = Just "1234567890"
-           }
-    , Case { description = "cleans another number"
-           , input       = "(612) 555-1212"
-           , expected    = Just "6125551212"
            }
     , Case { description = "cleans number with dots"
            , input       = "123.456.7890"
            , expected    = Just "1234567890"
            }
-    , Case { description = "cleans another number with dots"
-           , input       = "918.765.4321"
-           , expected    = Just "9187654321"
-           }
-    , Case { description = "valid when 11 digits and first is 1"
-           , input       = "12468013579"
-           , expected    = Just "2468013579"
-           }
-    , Case { description = "invalid when 11 digits"
-           , input       = "21234567890"
-           , expected    = Nothing
+    , Case { description = "cleans numbers with multiple spaces"
+           , input       = "123 456   7890   "
+           , expected    = Just "1234567890"
            }
     , Case { description = "invalid when 9 digits"
            , input       = "123456789"
            , expected    = Nothing
            }
+    , Case { description = "invalid when 11 digits"
+           , input       = "21234567890"
+           , expected    = Nothing
+           }
+    , Case { description = "valid when 11 digits and first is 1"
+           , input       = "11234567890"
+           , expected    = Just "1234567890"
+           }
     , Case { description = "invalid when 12 digits"
-           , input       = "123456789012"
+           , input       = "321234567890"
            , expected    = Nothing
            }
-    , Case { description = "invalid when empty"
-           , input       = ""
+    , Case { description = "invalid with letters"
+           , input       = "123-abc-7890"
            , expected    = Nothing
            }
-    , Case { description = "invalid when no digits present"
-           , input       = " (-) "
+    , Case { description = "invalid with punctuations"
+           , input       = "123-@:!-7890"
            , expected    = Nothing
            }
-    , Case { description = "valid with leading characters"
-           , input       = "my number is 235 813 2134"
-           , expected    = Just "2358132134"
-           }
-    , Case { description = "valid with trailing characters"
-           , input       = "987 654 3210 - bob"
-           , expected    = Just "9876543210"
-           }
-    , Case { description = "valid amidst text and punctuation"
-           , input       = "Here it is: 415-888-0000. Thanks!"
-           , expected    = Just "4158880000"
-           }
-    ]
-
-areaCodeCases :: [Case]
-areaCodeCases =
-    [ Case { description = "area code"
-           , input       = "1234567890"
-           , expected    = Just "123"
-           }
-    , Case { description = "area code with parentheses"
-           , input       = "(612) 555-1212"
-           , expected    = Just "612"
-           }
-    , Case { description = "area code with leading characters"
-           , input       = "my number is 235 813 2134"
-           , expected    = Just "235"
-           }
-    , Case { description = "invalid area code"
-           , input       = " (-) "
+    , Case { description = "invalid with right number of digits but letters mixed in"
+           , input       = "1a2b3c4d5e6f7g8h9i0j"
            , expected    = Nothing
-           }
-    ]
-
-prettyPrintCases :: [Case]
-prettyPrintCases =
-    [ Case { description = "pretty print"
-           , input       = "1234567890"
-           , expected    = Just "(123) 456-7890"
-           }
-    , Case { description = "pretty print with full US phone number"
-           , input       = "12345678901"
-           , expected    = Just "(234) 567-8901"
-           }
-    , Case { description = "pretty print amidst text and punctuation"
-           , input       = "Here it is: 415-888-0000. Thanks!"
-           , expected    = Just "(415) 888-0000"
            }
     ]


### PR DESCRIPTION
areaCode and prettyPrint are hereby removed.

https://github.com/exercism/x-common/pull/477

---

Reviewers: many cases were changed as a result of syncing to x-common. Are there any cases in particular you wish to keep?

In particular, note that all `Just` results are `1234567890`. If you wish for more variety, please speak up.