### PR TITLE
nucleotide-count: simplify to only nucleotideCounts

### DIFF
--- a/exercises/nucleotide-count/examples/success-standard/src/DNA.hs
+++ b/exercises/nucleotide-count/examples/success-standard/src/DNA.hs
@@ -1,9 +1,6 @@
-module DNA (count, nucleotideCounts) where
+module DNA (nucleotideCounts) where
 
-import Data.Map.Strict (Map, (!), fromDistinctAscList, fromListWith, findWithDefault)
-
-count :: Char -> String -> Either String Int
-count x xs = (!) <$> nucleotideCounts xs <*> valid x
+import Data.Map.Strict (Map, fromDistinctAscList, fromListWith, findWithDefault)
 
 nucleotideCounts :: String -> Either String (Map Char Int)
 nucleotideCounts xs = fromDistinctAscList <$> mapM count' "ACGT"

--- a/exercises/nucleotide-count/src/DNA.hs
+++ b/exercises/nucleotide-count/src/DNA.hs
@@ -1,9 +1,6 @@
-module DNA (count, nucleotideCounts) where
+module DNA (nucleotideCounts) where
 
 import Data.Map (Map)
-
-count :: Char -> String -> Either String Int
-count = error "You need to implement this function."
 
 nucleotideCounts :: String -> Either String (Map Char Int)
 nucleotideCounts = error "You need to implement this function."

--- a/exercises/nucleotide-count/test/Tests.hs
+++ b/exercises/nucleotide-count/test/Tests.hs
@@ -5,7 +5,7 @@ import Data.Map          (fromList)
 import Test.Hspec        (Spec, describe, it, shouldBe, shouldSatisfy)
 import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
 
-import DNA (count, nucleotideCounts)
+import DNA (nucleotideCounts)
 
 main :: IO ()
 main = hspecWith defaultConfig {configFastFail = True} specs
@@ -13,28 +13,9 @@ main = hspecWith defaultConfig {configFastFail = True} specs
 specs :: Spec
 specs = describe "nucleotide-count" $ do
 
-          -- As of 2016-07-27, there was no reference file
-          -- for the test cases in `exercism/x-common`.
+          -- Test cases adapted from `exercism/x-common/triangle.json` on 2017-01-31.
 
-          let x `matches`    y = x `shouldBe`  Right y
           let x `matchesMap` y = x `shouldBe` (Right . fromList) y
-
-          describe "count" $ do
-
-            it "empty dna strand has no adenosine" $
-              count 'A' "" `matches` 0
-
-            it "repetitive cytidine gets counted" $
-              count 'C' "CCCCC" `matches` 5
-
-            it "counts only thymidine" $
-              count 'T' "GGGGGTAACCCGG" `matches` 1
-
-            it "validates nucleotides" $
-              count 'X' "GACT" `shouldSatisfy` isLeft
-
-            it "validates strand" $
-              count 'G' "GACYT" `shouldSatisfy` isLeft
 
           describe "nucleotideCounts" $ do
 
@@ -58,4 +39,4 @@ specs = describe "nucleotide-count" $ do
                            , ('T', 21) ]
 
             it "validates strand" $
-              nucleotideCounts "GPAC" `shouldSatisfy` isLeft
+              nucleotideCounts "AGXXACT" `shouldSatisfy` isLeft


### PR DESCRIPTION
It was decided that the exercise was doing too many things, and count
really is just one element of nucleotideCounts anyway.

https://github.com/exercism/x-common/pull/505