### PR TITLE
secret-handshake: use cases from x-common

### DIFF
--- a/config.json
+++ b/config.json
@@ -146,7 +146,6 @@
       "slug": "secret-handshake",
       "difficulty": 3,
       "topics": [
-        "instance custom"
       ]
     },
     {

--- a/exercises/secret-handshake/.meta/DONT-TEST-STUB
+++ b/exercises/secret-handshake/.meta/DONT-TEST-STUB
@@ -1,1 +1,0 @@
-No signature, so students can figure out accepting strings and ints.

--- a/exercises/secret-handshake/HINTS.md
+++ b/exercises/secret-handshake/HINTS.md
@@ -1,6 +1,0 @@
-## Hints
-
-The trick to this one is defining the appropriate typeclass or typeclasses
-to make handshake work with both Int and String. Granted, this is probably
-not good API design for this exercise, but the technique is useful.
-You may want to see http://www.haskell.org/haskellwiki/List_instance

--- a/exercises/secret-handshake/examples/success-standard/src/SecretHandshake.hs
+++ b/exercises/secret-handshake/examples/success-standard/src/SecretHandshake.hs
@@ -1,6 +1,5 @@
 module SecretHandshake (handshake) where
 
-import Numeric (readInt)
 import Data.Bits (testBit)
 
 data Action = Wink
@@ -10,7 +9,7 @@ data Action = Wink
             | Reverse
             deriving (Show, Eq, Enum, Bounded)
 
-handshake :: Handshake a => a -> [String]
+handshake :: Int -> [String]
 handshake = foldr f [] . toActions
   where f Reverse acc = reverse acc
         f action acc = toString action:acc
@@ -21,22 +20,5 @@ handshake = foldr f [] . toActions
           Jump          -> "jump"
           Reverse       -> undefined
 
-class Handshake a where
-  toActions :: a -> [Action]
-
-instance Handshake Int where
-  toActions n = [act | act <- Reverse:[Wink .. Jump], n `testBit` fromEnum act]
-
-class BinParsable a where
-  listToInt :: [a] -> Int
-
-instance BinParsable Char where
-    listToInt s = case readInt 2 isBin parseBin s of
-      [(n, "")] -> n
-      _         -> 0
-      where isBin c = c == '0' || c == '1'
-            parseBin = fromEnum . ('1'==)
-
-
-instance BinParsable a => Handshake [a] where
-  toActions = toActions . listToInt
+toActions :: Int -> [Action]
+toActions n = [act | act <- Reverse:[Wink .. Jump], n `testBit` fromEnum act]

--- a/exercises/secret-handshake/src/SecretHandshake.hs
+++ b/exercises/secret-handshake/src/SecretHandshake.hs
@@ -1,3 +1,4 @@
 module SecretHandshake (handshake) where
 
+handshake :: Int -> [String]
 handshake = error "You need to implement this function."

--- a/exercises/secret-handshake/test/Tests.hs
+++ b/exercises/secret-handshake/test/Tests.hs
@@ -9,43 +9,40 @@ main = hspecWith defaultConfig {configFastFail = True} specs
 specs :: Spec
 specs = describe "secret-handshake" $ do
 
-    -- As of 2016-09-12, there was no reference file
-    -- for the test cases in `exercism/x-common`.
+    -- Test cases adapted from `exercism/x-common/secret-handshake` on 2017-01-31.
 
-    it "1 to wink" $ do
+    it "wink for 1" $
       handshake (1 :: Int) `shouldBe` ["wink"]
-      handshake "1"        `shouldBe` ["wink"]
 
-    it "10 to double blink" $ do
+    it "double blink for 10" $
       handshake (2 :: Int) `shouldBe` ["double blink"]
-      handshake "10"       `shouldBe` ["double blink"]
 
-    it "100 to close your eyes" $ do
+    it "close your eyes for 100" $
       handshake (4 :: Int) `shouldBe` ["close your eyes"]
-      handshake "100"      `shouldBe` ["close your eyes"]
 
-    it "1000 to jump" $ do
+    it "jump for 1000" $
       handshake (8 :: Int) `shouldBe` ["jump"]
-      handshake "1000"     `shouldBe` ["jump"]
 
-    it "11 to wink and double blink" $ do
+    it "combine two actions" $
       handshake (3 :: Int) `shouldBe` ["wink", "double blink"]
-      handshake "11"       `shouldBe` ["wink", "double blink"]
 
-    it "10011 to double blink and wink" $ do
+    it "reverse two actions" $
       handshake (19 :: Int) `shouldBe` ["double blink", "wink"]
-      handshake "10011"     `shouldBe` ["double blink", "wink"]
 
-    it "11111 to jump, close your eyes, double blink, and wink" $ do
+    it "reversing one action gives the same action" $
+      handshake (24 :: Int) `shouldBe` ["jump"]
+
+    it "reversing no actions still gives no actions" $
+      handshake (16 :: Int) `shouldBe` []
+
+    it "all possible actions" $
+      handshake (15 :: Int) `shouldBe` ["wink", "double blink", "close your eyes", "jump"]
+
+    it "reverse all possible actions" $
       handshake (31 :: Int) `shouldBe` ["jump", "close your eyes", "double blink", "wink"]
-      handshake "11111"     `shouldBe` ["jump", "close your eyes", "double blink", "wink"]
 
-    it "zero" $ do
+    it "do nothing for zero" $
       handshake (0 :: Int) `shouldBe` []
-      handshake "0"        `shouldBe` []
 
-    it "gibberish" $
-      handshake "piggies" `shouldBe` []
-
-    it "partial gibberish" $
-      handshake "1piggies" `shouldBe` []
+    it "do nothing if lower 5 bits not set" $
+      handshake (32 :: Int) `shouldBe` []


### PR DESCRIPTION
This removes the string cases; the function-under-test is now only
obligated to accept integers.

Note that the now-deleted HINTS.md accepted that this API design was
bad, so it is good to get rid of it.

---

Reviewers: this is a bit of a shame, as we are getting rid of a unique request of students (to make a function take both a string and a number). But I also think that this problem might be a bit too early to make this request. Do you want to keep it and/or revive this concept in another problem?

The only other problem in which we request students to implement a typeclass is in Clock.