### PR TITLE
bob: Run tests from JSON

### DIFF
--- a/exercises/bob/examples/success-standard/package.yaml
+++ b/exercises/bob/examples/success-standard/package.yaml
@@ -13,4 +13,7 @@ tests:
     source-dirs: test
     dependencies:
       - bob
+      - aeson
+      - bytestring
       - hspec
+      - HUnit

--- a/exercises/bob/package.yaml
+++ b/exercises/bob/package.yaml
@@ -16,4 +16,7 @@ tests:
     source-dirs: test
     dependencies:
       - bob
+      - aeson
+      - bytestring
       - hspec
+      - HUnit

--- a/exercises/bob/src/Bob.hs
+++ b/exercises/bob/src/Bob.hs
@@ -1,4 +1,4 @@
 module Bob (responseFor) where
 
 responseFor :: String -> String
-responseFor = error "You need to implement this function."
+responseFor xs = error "You need to implement this function."

--- a/exercises/bob/test/canonical-data.json
+++ b/exercises/bob/test/canonical-data.json
@@ -1,0 +1,184 @@
+{
+  "exercise":"bob",
+  "version":"0.1.0",
+  "comments":[
+    "Whatever."
+  ],
+  "group":[
+    {
+      "response":{
+        "description":"stating something",
+        "input":"Tom-ay-to, tom-aaaah-to.",
+        "expected":"Whatever."
+      }
+    },
+    {
+      "response":{
+        "description":"shouting",
+        "input":"WATCH OUT!",
+        "expected":"Whoa, chill out!"
+      }
+    },
+    {
+      "response":{
+        "description":"shouting gibberish",
+        "input":"FCECDFCAAB",
+        "expected":"Whoa, chill out!"
+      }
+    },
+    {
+      "response":{
+        "description":"asking a question",
+        "input":"Does this cryogenic chamber make me look fat?",
+        "expected":"Sure."
+      }
+    },
+    {
+      "response":{
+        "description":"asking a numeric question",
+        "input":"You are, what, like 15?",
+        "expected":"Sure."
+      }
+    },
+    {
+      "response":{
+        "description":"asking gibberish",
+        "input":"fffbbcbeab?",
+        "expected":"Sure."
+      }
+    },
+    {
+      "response":{
+        "description":"talking forcefully",
+        "input":"Let's go make out behind the gym!",
+        "expected":"Whatever."
+      }
+    },
+    {
+      "response":{
+        "description":"using acronyms in regular speech",
+        "input":"It's OK if you don't want to go to the DMV.",
+        "expected":"Whatever."
+      }
+    },
+    {
+      "response":{
+        "description":"forceful question",
+        "input":"WHAT THE HELL WERE YOU THINKING?",
+        "expected":"Whoa, chill out!"
+      }
+    },
+    {
+      "response":{
+        "description":"shouting numbers",
+        "input":"1, 2, 3 GO!",
+        "expected":"Whoa, chill out!"
+      }
+    },
+    {
+      "response":{
+        "description":"only numbers",
+        "input":"1, 2, 3",
+        "expected":"Whatever."
+      }
+    },
+    {
+      "response":{
+        "description":"question with only numbers",
+        "input":"4?",
+        "expected":"Sure."
+      }
+    },
+    {
+      "response":{
+        "description":"shouting with special characters",
+        "input":"ZOMG THE %^*@#$(*^ ZOMBIES ARE COMING!!11!!1!",
+        "expected":"Whoa, chill out!"
+      }
+    },
+    {
+      "response":{
+        "description":"shouting with no exclamation mark",
+        "input":"I HATE YOU",
+        "expected":"Whoa, chill out!"
+      }
+    },
+    {
+      "response":{
+        "description":"statement containing question mark",
+        "input":"Ending with ? means a question.",
+        "expected":"Whatever."
+      }
+    },
+    {
+      "response":{
+        "description":"non-letters with question",
+        "input":":) ?",
+        "expected":"Sure."
+      }
+    },
+    {
+      "response":{
+        "description":"prattling on",
+        "input":"Wait! Hang on. Are you going to be OK?",
+        "expected":"Sure."
+      }
+    },
+    {
+      "response":{
+        "description":"silence",
+        "input":"",
+        "expected":"Fine. Be that way!"
+      }
+    },
+    {
+      "response":{
+        "description":"prolonged silence",
+        "input":"          ",
+        "expected":"Fine. Be that way!"
+      }
+    },
+    {
+      "response":{
+        "description":"alternate silence",
+        "input":"\t\t\t\t\t\t\t\t\t\t",
+        "expected":"Fine. Be that way!"
+      }
+    },
+    {
+      "response":{
+        "description":"multiple line question",
+        "input":"\nDoes this cryogenic chamber make me look fat?\nno",
+        "expected":"Whatever."
+      }
+    },
+    {
+      "response":{
+        "description":"starting with whitespace",
+        "input":"         hmmmmmmm...",
+        "expected":"Whatever."
+      }
+    },
+    {
+      "response":{
+        "description":"ending with whitespace",
+        "input":"Okay if like my  spacebar  quite a bit?   ",
+        "expected":"Sure."
+      }
+    },
+    {
+      "response":{
+        "description":"other whitespace",
+        "input":"\n\r \t",
+        "expected":"Fine. Be that way!"
+      }
+    },
+    {
+      "response":{
+        "description":"non-question ending with whitespace",
+        "input":"This is a statement ending with whitespace      ",
+        "expected":"Whatever."
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Every time an exercise changes in `x-common`, we usually have to do one of the following:

- Change the test suite logic.
- Update the test data.

The former is mostly unavoidable, because `canonical-data.json` doesn't contain enough information to allow deriving Haskell types from it, and this situation will probably never change, as it would force other tracks to deal with a highly complex JSON schema.

The latter can be automated, an this is usually done using generators. I propose an alternative!

#### What if the test suite could read `canonical-data.json` directly?

##### Disadvantages:

- Test suites depending on `aeson` and `bytestring` (**Edit:** +`HUnit`).
- Slower first-time compilation. (I don't know how much)
- Risk of failure at runtime. (If the user changes the JSON file, otherwise Travis will catch it)
- Users may try to open a PR to change `canonical-data.json` in `xhaskell`.
- **Edit:** It may be annoying for users to look at two test files instead of one.

##### Advantages

- Easier maintenance.
- Less transcription/update error. (They are probably uncommon anyway)
- Decoupling of test data and test logic.
- `canonical-data.json` validation and testing for free.
- Shorter JSON patching cycle.

#### Proof of concept

The PR applies these ideas to `bob`, which is an easy case. More elaborated cases can be dealt with, but some would benefit from a standardization of the the JSON schema.

#### So...what do you think of it?