### PR TITLE
simple-linked-list: Add QuickCheck tests

### DIFF
--- a/exercises/simple-linked-list/examples/success-standard/package.yaml
+++ b/exercises/simple-linked-list/examples/success-standard/package.yaml
@@ -14,3 +14,4 @@ tests:
     dependencies:
       - simple-linked-list
       - hspec
+      - QuickCheck

--- a/exercises/simple-linked-list/examples/success-standard/src/LinkedList.hs
+++ b/exercises/simple-linked-list/examples/success-standard/src/LinkedList.hs
@@ -5,6 +5,7 @@ module LinkedList ( LinkedList
 data LinkedList a = Nil
                   | Cons { datum :: a
                          , next :: LinkedList a }
+  deriving (Eq, Show)
 
 new :: a -> LinkedList a -> LinkedList a
 new = Cons

--- a/exercises/simple-linked-list/package.yaml
+++ b/exercises/simple-linked-list/package.yaml
@@ -17,3 +17,4 @@ tests:
     dependencies:
       - simple-linked-list
       - hspec
+      - QuickCheck

--- a/exercises/simple-linked-list/src/LinkedList.hs
+++ b/exercises/simple-linked-list/src/LinkedList.hs
@@ -10,7 +10,7 @@ module LinkedList
     , toList
     ) where
 
-data LinkedList a = Dummy
+data LinkedList a = Dummy deriving (Eq, Show)
 
 datum :: LinkedList a -> a
 datum linkedList = error "You need to implement this function."


### PR DESCRIPTION
#498 Property-based Testing
This is just to have some concrete code for discussion.

I simply used the existing QuickCheck tests from `octal` and `trinary` to get started.

One immediate problem is the compiler warning about the orphanned instance declaration. Is there some easy way to solve this?