### PR TITLE
Add explicit args to Exercises - Part 1

### DIFF
--- a/exercises/allergies/src/Allergies.hs
+++ b/exercises/allergies/src/Allergies.hs
@@ -11,7 +11,7 @@ data Allergen = Eggs
               deriving (Eq)
 
 allergies :: Int -> [Allergen]
-allergies = error "You need to implement this function."
+allergies score = error "You need to implement this function."
 
 isAllergicTo :: Allergen -> Int -> Bool
-isAllergicTo = error "You need to implement this function."
+isAllergicTo allergen score = error "You need to implement this function."

--- a/exercises/atbash-cipher/src/Atbash.hs
+++ b/exercises/atbash-cipher/src/Atbash.hs
@@ -1,7 +1,7 @@
 module Atbash (decode, encode) where
 
 decode :: String -> String
-decode = error "You need to implement this function."
+decode phrase = error "You need to implement this function."
 
 encode :: String -> String
-encode = error "You need to implement this function."
+encode phrase = error "You need to implement this function."

--- a/exercises/bank-account/src/BankAccount.hs
+++ b/exercises/bank-account/src/BankAccount.hs
@@ -9,13 +9,13 @@ module BankAccount
 data BankAccount = Dummy
 
 closeAccount :: BankAccount -> IO ()
-closeAccount = error "You need to implement this function."
+closeAccount account = error "You need to implement this function."
 
 getBalance :: BankAccount -> IO (Maybe Integer)
-getBalance = error "You need to implement this function."
+getBalance account = error "You need to implement this function."
 
 incrementBalance :: BankAccount -> Integer -> IO (Maybe Integer)
-incrementBalance = error "You need to implement this function."
+incrementBalance account amount = error "You need to implement this function."
 
 openAccount :: IO BankAccount
 openAccount = error "You need to implement this function."

--- a/exercises/binary-search-tree/src/BST.hs
+++ b/exercises/binary-search-tree/src/BST.hs
@@ -13,25 +13,25 @@ module BST
 data BST a = Dummy deriving (Eq, Show)
 
 bstLeft :: BST a -> Maybe (BST a)
-bstLeft = error "You need to implement this function."
+bstLeft tree = error "You need to implement this function."
 
 bstRight :: BST a -> Maybe (BST a)
-bstRight = error "You need to implement this function."
+bstRight tree = error "You need to implement this function."
 
 bstValue :: BST a -> Maybe a
-bstValue = error "You need to implement this function."
+bstValue tree = error "You need to implement this function."
 
 empty :: BST a
 empty = error "You need to implement this function."
 
 fromList :: Ord a => [a] -> BST a
-fromList = error "You need to implement this function."
+fromList xs = error "You need to implement this function."
 
 insert :: Ord a => a -> BST a -> BST a
-insert = error "You need to implement this function."
+insert x tree = error "You need to implement this function."
 
 singleton :: a -> BST a
-singleton = error "You need to implement this function."
+singleton x = error "You need to implement this function."
 
 toList :: BST a -> [a]
-toList = error "You need to implement this function."
+toList tree = error "You need to implement this function."

--- a/exercises/bowling/src/Bowling.hs
+++ b/exercises/bowling/src/Bowling.hs
@@ -5,5 +5,5 @@ data BowlingError = IncompleteGame
   deriving (Eq, Show)
 
 score :: [Int] -> Either BowlingError Int
-score = error "You need to implement this function."
+score rolls = error "You need to implement this function."
 

--- a/exercises/clock/src/Clock.hs
+++ b/exercises/clock/src/Clock.hs
@@ -3,13 +3,13 @@ module Clock (clockHour, clockMin, fromHourMin, toString) where
 data Clock = Dummy
 
 clockHour :: Clock -> Int
-clockHour = error "You need to implement this function."
+clockHour clock = error "You need to implement this function."
 
 clockMin :: Clock -> Int
-clockMin = error "You need to implement this function."
+clockMin clock = error "You need to implement this function."
 
 fromHourMin :: Int -> Int -> Clock
-fromHourMin = error "You need to implement this function."
+fromHourMin hour min = error "You need to implement this function."
 
 toString :: Clock -> String
-toString = error "You need to implement this function."
+toString clock = error "You need to implement this function."

--- a/exercises/connect/src/Connect.hs
+++ b/exercises/connect/src/Connect.hs
@@ -3,4 +3,4 @@ module Connect (Mark(..), winner) where
 data Mark = Cross | Nought deriving (Eq, Show)
 
 winner :: [String] -> Maybe Mark
-winner = error "You need to implement this function."
+winner board = error "You need to implement this function."

--- a/exercises/crypto-square/src/CryptoSquare.hs
+++ b/exercises/crypto-square/src/CryptoSquare.hs
@@ -1,4 +1,4 @@
 module CryptoSquare (encode) where
 
 encode :: String -> String
-encode = error "You need to implement this function."
+encode xs = error "You need to implement this function."

--- a/exercises/custom-set/src/CustomSet.hs
+++ b/exercises/custom-set/src/CustomSet.hs
@@ -19,40 +19,40 @@ import Prelude hiding (null)
 data CustomSet a = Dummy deriving (Eq, Show)
 
 delete :: a -> CustomSet a -> CustomSet a
-delete = error "You need to implement this function."
+delete x set = error "You need to implement this function."
 
 difference :: CustomSet a -> CustomSet a -> CustomSet a
-difference = error "You need to implement this function."
+difference setA setB = error "You need to implement this function."
 
 empty :: CustomSet a
 empty = error "You need to implement this function."
 
 fromList :: [a] -> CustomSet a
-fromList = error "You need to implement this function."
+fromList xs = error "You need to implement this function."
 
 insert :: a -> CustomSet a -> CustomSet a
-insert = error "You need to implement this function."
+insert x set = error "You need to implement this function."
 
 intersection :: CustomSet a -> CustomSet a -> CustomSet a
-intersection = error "You need to implement this function."
+intersection setA setB = error "You need to implement this function."
 
 isDisjointFrom :: CustomSet a -> CustomSet a -> Bool
-isDisjointFrom = error "You need to implement this function."
+isDisjointFrom setA setB = error "You need to implement this function."
 
 isSubsetOf :: CustomSet a -> CustomSet a -> Bool
-isSubsetOf = error "You need to implement this function."
+isSubsetOf setA setB = error "You need to implement this function."
 
 member :: a -> CustomSet a -> Bool
-member = error "You need to implement this function."
+member x set = error "You need to implement this function."
 
 null :: CustomSet a -> Bool
-null = error "You need to implement this function."
+null set = error "You need to implement this function."
 
 size :: CustomSet a -> Int
-size = error "You need to implement this function."
+size set = error "You need to implement this function."
 
 toList :: CustomSet a -> [a]
-toList = error "You need to implement this function."
+toList set = error "You need to implement this function."
 
 union :: CustomSet a -> CustomSet a -> CustomSet a
-union = error "You need to implement this function."
+union setA setB = error "You need to implement this function."

--- a/exercises/difference-of-squares/src/Squares.hs
+++ b/exercises/difference-of-squares/src/Squares.hs
@@ -1,10 +1,10 @@
 module Squares (difference, squareOfSums, sumOfSquares) where
 
 difference :: Integral a => a -> a
-difference = error "You need to implement this function."
+difference n = error "You need to implement this function."
 
 squareOfSums :: Integral a => a -> a
-squareOfSums = error "You need to implement this function."
+squareOfSums n = error "You need to implement this function."
 
 sumOfSquares :: Integral a => a -> a
-sumOfSquares = error "You need to implement this function."
+sumOfSquares n = error "You need to implement this function."

--- a/exercises/etl/src/ETL.hs
+++ b/exercises/etl/src/ETL.hs
@@ -3,4 +3,4 @@ module ETL (transform) where
 import Data.Map (Map)
 
 transform :: Map a String -> Map Char a
-transform = error "You need to implement this function."
+transform legacyData = error "You need to implement this function."

--- a/exercises/forth/src/Forth.hs
+++ b/exercises/forth/src/Forth.hs
@@ -23,7 +23,7 @@ empty :: ForthState
 empty = error "You need to implement this function."
 
 evalText :: Text -> ForthState -> Either ForthError ForthState
-evalText = error "You need to implement this function."
+evalText text stack = error "You need to implement this function."
 
 toList :: ForthState -> [Int]
-toList = error "You need to implement this function."
+toList stack = error "You need to implement this function."

--- a/exercises/go-counting/src/Counting.hs
+++ b/exercises/go-counting/src/Counting.hs
@@ -10,7 +10,7 @@ data Color = Black | White deriving (Eq, Ord, Show)
 type Coord = (Int, Int)
 
 territories :: [String] -> [(Set Coord, Maybe Color)]
-territories = error "You need to implement this function."
+territories board = error "You need to implement this function."
 
 territoryFor :: [String] -> Coord -> Maybe (Set Coord, Maybe Color)
-territoryFor = error "You need to implement this function."
+territoryFor board coord = error "You need to implement this function."

--- a/exercises/kindergarten-garden/src/Garden.hs
+++ b/exercises/kindergarten-garden/src/Garden.hs
@@ -14,10 +14,10 @@ data Plant = Clover
            deriving (Eq, Show)
 
 defaultGarden :: String -> Map String [Plant]
-defaultGarden = error "You need to implement this function."
+defaultGarden plants = error "You need to implement this function."
 
 garden :: [String] -> String -> Map String [Plant]
-garden = error "You need to implement this function."
+garden students plants = error "You need to implement this function."
 
 lookupPlants :: String -> Map String [Plant] -> [Plant]
-lookupPlants = error "You need to implement this function."
+lookupPlants student garden = error "You need to implement this function."

--- a/exercises/largest-series-product/src/Series.hs
+++ b/exercises/largest-series-product/src/Series.hs
@@ -1,4 +1,4 @@
 module Series (largestProduct) where
 
 largestProduct :: Int -> String -> Maybe Integer
-largestProduct = error "You need to implement this function."
+largestProduct series digits = error "You need to implement this function."

--- a/exercises/lens-person/src/Person.hs
+++ b/exercises/lens-person/src/Person.hs
@@ -31,13 +31,13 @@ data Address = Address { _street      :: String
                        }
 
 bornStreet :: Born -> String
-bornStreet = error "You need to implement this function."
+bornStreet born = error "You need to implement this function."
 
 setCurrentStreet :: String -> Person -> Person
-setCurrentStreet = error "You need to implement this function."
+setCurrentStreet street person = error "You need to implement this function."
 
 setBirthMonth :: Int -> Person -> Person
-setBirthMonth = error "You need to implement this function."
+setBirthMonth month person = error "You need to implement this function."
 
 renameStreets :: (String -> String) -> Person -> Person
-renameStreets = error "You need to implement this function."
+renameStreets f person = error "You need to implement this function."


### PR DESCRIPTION
Part of #473 

Perhaps the next PRs will be smaller, so they can be reviewed easier.

I was thinking about some of the exercises covered in this PR and how much more complex they are in comparison to the first 10 - 15 available exercises (the ones I've completed so far).
Once the student get there, he will have crossed a few Haskell / FP concepts, which is one of the goals of this Track.

Consequently, wouldn't [eta-conversion](https://wiki.haskell.org/Eta_conversion) also be part of the concepts he should familiarize with? Therefore, I believe that, starting from a complex enough exercise, keeping the function arguments out would create a better learning experience.