### PR TITLE
Revert "pov: Add dummy symbolic link (#454)" and "common: Add folder with common exercise's files"

### DIFF
--- a/common/stack.yaml
+++ b/common/stack.yaml
@@ -1,1 +1,0 @@
-resolver: lts-8.2

--- a/config.json
+++ b/config.json
@@ -510,7 +510,6 @@
     "trinary"
   ],
   "ignored": [
-    "common",
     "docs",
     "img"
   ],

--- a/exercises/pov/.dummylink
+++ b/exercises/pov/.dummylink
@@ -1,1 +1,0 @@
-../../common/stack.yaml


### PR DESCRIPTION
Closes #442 

Details in individual commit messages.

Let me merge this one since it has a "Closes exercism/trackler#13" in it and I'm the issue creator so it'll only work if I merge it.