### PR TITLE
all exercises: declare compliance with x-common, where applicable

### DIFF
--- a/exercises/all-your-base/package.yaml
+++ b/exercises/all-your-base/package.yaml
@@ -1,5 +1,5 @@
 name: all-your-base
-version: 0.9.0.1 # 2016-06-29
+version: 1.0.0.2
 
 dependencies:
   - base

--- a/exercises/allergies/package.yaml
+++ b/exercises/allergies/package.yaml
@@ -1,5 +1,5 @@
 name: allergies
-version: 0.9.0.1 # 2016-08-01
+version: 1.0.0.2
 
 dependencies:
   - base

--- a/exercises/alphametics/package.yaml
+++ b/exercises/alphametics/package.yaml
@@ -1,5 +1,5 @@
 name: alphametics
-version: 0.9.0.1 # 2016-10-26
+version: 1.0.0.2
 
 dependencies:
   - base

--- a/exercises/anagram/package.yaml
+++ b/exercises/anagram/package.yaml
@@ -1,5 +1,5 @@
 name: anagram
-version: 0.9.0.1 # 2016-10-26
+version: 1.0.0.2
 
 dependencies:
   - base

--- a/exercises/atbash-cipher/package.yaml
+++ b/exercises/atbash-cipher/package.yaml
@@ -1,5 +1,5 @@
 name: atbash-cipher
-version: 0.9.0.1 # 2017-02-01
+version: 1.0.0.2
 
 dependencies:
   - base

--- a/exercises/bob/package.yaml
+++ b/exercises/bob/package.yaml
@@ -1,5 +1,5 @@
 name: bob
-version: 0.9.0.1 # 2016-11-29
+version: 1.0.0.2
 
 dependencies:
   - base

--- a/exercises/clock/package.yaml
+++ b/exercises/clock/package.yaml
@@ -1,5 +1,5 @@
 name: clock
-version: 0.9.0.1 # 2016-03-29
+version: 1.0.1.2
 
 dependencies:
   - base

--- a/exercises/connect/package.yaml
+++ b/exercises/connect/package.yaml
@@ -1,5 +1,5 @@
 name: connect
-version: 0.9.0.1 # 2016-09-16
+version: 1.0.0.2
 
 dependencies:
   - base

--- a/exercises/custom-set/package.yaml
+++ b/exercises/custom-set/package.yaml
@@ -1,5 +1,5 @@
 name: custom-set
-version: 0.9.0.1 # 2016-09-03
+version: 1.0.1.2
 
 dependencies:
   - base

--- a/exercises/difference-of-squares/package.yaml
+++ b/exercises/difference-of-squares/package.yaml
@@ -1,5 +1,5 @@
 name: difference-of-squares
-version: 0.9.0.1 # 2016-08-03
+version: 1.0.0.2
 
 dependencies:
   - base

--- a/exercises/dominoes/package.yaml
+++ b/exercises/dominoes/package.yaml
@@ -1,5 +1,5 @@
 name: dominoes
-version: 0.9.0.1 # 2016-11-11
+version: 1.0.0.2
 
 dependencies:
   - base

--- a/exercises/etl/package.yaml
+++ b/exercises/etl/package.yaml
@@ -1,5 +1,5 @@
 name: etl
-version: 0.9.0.1 # 2017-01-31
+version: 1.0.0.2
 
 dependencies:
   - base

--- a/exercises/forth/package.yaml
+++ b/exercises/forth/package.yaml
@@ -1,5 +1,5 @@
 name: forth
-version: 0.9.0.1 # 2017-02-01
+version: 1.0.0.2
 
 dependencies:
   - base

--- a/exercises/grains/package.yaml
+++ b/exercises/grains/package.yaml
@@ -1,5 +1,5 @@
 name: grains
-version: 0.9.0.1 # 2016-11-06
+version: 1.0.0.2
 
 dependencies:
   - base

--- a/exercises/hamming/package.yaml
+++ b/exercises/hamming/package.yaml
@@ -1,5 +1,5 @@
 name: hamming
-version: 0.9.0.1 # 2016-07-12
+version: 1.0.0.2
 
 dependencies:
   - base

--- a/exercises/hello-world/package.yaml
+++ b/exercises/hello-world/package.yaml
@@ -1,5 +1,5 @@
 name: hello-world
-version: 0.1.0.1
+version: 1.0.0.2
 
 dependencies:
   - base

--- a/exercises/meetup/package.yaml
+++ b/exercises/meetup/package.yaml
@@ -1,5 +1,5 @@
 name: meetup
-version: 0.9.0.1 # 2016-07-26
+version: 1.0.0.2
 
 dependencies:
   - base

--- a/exercises/minesweeper/package.yaml
+++ b/exercises/minesweeper/package.yaml
@@ -1,5 +1,5 @@
 name: minesweeper
-version: 0.9.0.1 # 2016-09-05
+version: 1.0.0.2
 
 dependencies:
   - base

--- a/exercises/nth-prime/package.yaml
+++ b/exercises/nth-prime/package.yaml
@@ -1,5 +1,5 @@
 name: nth-prime
-version: 0.9.0.1 # 2016-09-19
+version: 1.0.0.2
 
 dependencies:
   - base

--- a/exercises/nucleotide-count/package.yaml
+++ b/exercises/nucleotide-count/package.yaml
@@ -1,5 +1,5 @@
 name: nucleotide-count
-version: 0.9.0.1 # 2017-01-31
+version: 1.0.0.2
 
 dependencies:
   - base

--- a/exercises/ocr-numbers/package.yaml
+++ b/exercises/ocr-numbers/package.yaml
@@ -1,5 +1,5 @@
 name: ocr-numbers
-version: 0.9.0.1 # 2016-08-09
+version: 1.0.0.2
 
 dependencies:
   - base

--- a/exercises/pascals-triangle/package.yaml
+++ b/exercises/pascals-triangle/package.yaml
@@ -1,5 +1,5 @@
 name: pascals-triangle
-version: 0.9.0.1 # 2016-09-14
+version: 1.0.0.2
 
 dependencies:
   - base

--- a/exercises/phone-number/package.yaml
+++ b/exercises/phone-number/package.yaml
@@ -1,5 +1,5 @@
 name: phone-number
-version: 0.9.0.1 # 2017-01-31
+version: 1.0.0.2
 
 dependencies:
   - base

--- a/exercises/pig-latin/package.yaml
+++ b/exercises/pig-latin/package.yaml
@@ -1,5 +1,5 @@
 name: pig-latin
-version: 0.9.0.1 # 2016-11-06
+version: 1.0.0.2
 
 dependencies:
   - base

--- a/exercises/pov/package.yaml
+++ b/exercises/pov/package.yaml
@@ -1,5 +1,5 @@
 name: pov
-version: 0.9.0.1 # 2016-11-06
+version: 1.0.0.2
 
 dependencies:
   - base

--- a/exercises/prime-factors/package.yaml
+++ b/exercises/prime-factors/package.yaml
@@ -1,5 +1,5 @@
 name: prime-factors
-version: 0.9.0.1 # 2017-02-01
+version: 1.0.0.2
 
 dependencies:
   - base

--- a/exercises/queen-attack/package.yaml
+++ b/exercises/queen-attack/package.yaml
@@ -1,5 +1,5 @@
 name: queen-attack
-version: 0.9.0.1 # 2016-08-02
+version: 1.0.0.2
 
 dependencies:
   - base

--- a/exercises/raindrops/package.yaml
+++ b/exercises/raindrops/package.yaml
@@ -1,5 +1,5 @@
 name: raindrops
-version: 0.9.0.1 # 2016-09-19
+version: 1.0.0.2
 
 dependencies:
   - base

--- a/exercises/rna-transcription/package.yaml
+++ b/exercises/rna-transcription/package.yaml
@@ -1,5 +1,5 @@
 name: rna-transcription
-version: 0.9.0.1 # 2016-07-24
+version: 1.0.0.2
 
 dependencies:
   - base

--- a/exercises/robot-simulator/package.yaml
+++ b/exercises/robot-simulator/package.yaml
@@ -1,5 +1,5 @@
 name: robot-simulator
-version: 0.9.0.1 # 2016-08-02
+version: 1.0.0.2
 
 dependencies:
   - base

--- a/exercises/say/package.yaml
+++ b/exercises/say/package.yaml
@@ -1,5 +1,5 @@
 name: say
-version: 0.9.0.1 # 2016-11-06
+version: 1.0.0.2
 
 dependencies:
   - base

--- a/exercises/scrabble-score/package.yaml
+++ b/exercises/scrabble-score/package.yaml
@@ -1,5 +1,5 @@
 name: scrabble-score
-version: 0.9.0.1 # 2017-02-01
+version: 1.0.0.2
 
 dependencies:
   - base

--- a/exercises/secret-handshake/package.yaml
+++ b/exercises/secret-handshake/package.yaml
@@ -1,5 +1,5 @@
 name: secret-handshake
-version: 0.9.0.1 # 2017-01-31
+version: 1.0.0.2
 
 dependencies:
   - base

--- a/exercises/sieve/package.yaml
+++ b/exercises/sieve/package.yaml
@@ -1,5 +1,5 @@
 name: sieve
-version: 0.9.0.1 # 2016-09-12
+version: 1.0.0.2
 
 dependencies:
   - base

--- a/exercises/space-age/package.yaml
+++ b/exercises/space-age/package.yaml
@@ -1,5 +1,5 @@
 name: space-age
-version: 0.9.0.1 # 2016-07-27
+version: 1.0.0.2
 
 dependencies:
   - base

--- a/exercises/sublist/package.yaml
+++ b/exercises/sublist/package.yaml
@@ -1,5 +1,5 @@
 name: sublist
-version: 0.9.0.1 # 2016-11-29
+version: 1.0.0.2
 
 dependencies:
   - base

--- a/exercises/sum-of-multiples/package.yaml
+++ b/exercises/sum-of-multiples/package.yaml
@@ -1,5 +1,5 @@
 name: sum-of-multiples
-version: 0.9.0.1 # 2016-07-27
+version: 1.0.0.2
 
 dependencies:
   - base

--- a/exercises/word-count/package.yaml
+++ b/exercises/word-count/package.yaml
@@ -1,5 +1,5 @@
 name: word-count
-version: 0.9.0.1 # 2016-11-06
+version: 1.0.0.2
 
 dependencies:
   - base

--- a/exercises/wordy/package.yaml
+++ b/exercises/wordy/package.yaml
@@ -1,5 +1,5 @@
 name: wordy
-version: 0.9.0.1 # 2016-08-10
+version: 1.0.0.2
 
 dependencies:
   - base


### PR DESCRIPTION
The metholodogy was as such:

For all 0.9.0 exercises, check all x-common changes made since the date declared. If the only x-common changes were to convert the JSON file to the schema, declare compliance with 1.0.0. Otherwise (there were other changes before converting the JSON file to the schema), leave version at 0.9.0.

If a 1.0.x change was made that xhaskell has already complied with or does not need to, declare compliance with that too.

In no case has compliance been declared with a version > 1.0.x.

This trusts that:

* all dates were transferred correctly in #523.
* if in the past we declared x-common compliance at a certain date, that compliance was an accurate declaration
* I did not make any errors in judgment in whether there was a substantial change (yes, it was a human process)

---

Exercises already up to date (3):

                  bracket-push: 1.1.0.1 == 1.1.0
                       pangram: 1.0.0.1 == 1.0.0
                       acronym: 1.0.0.1 == 1.0.0

Exercises updated in this PR now up to date (36):

                     pig-latin: 1.0.0.2 == 1.0.0
                        meetup: 1.0.0.2 == 1.0.0
              pascals-triangle: 1.0.0.2 == 1.0.0
                       hamming: 1.0.0.2 == 1.0.0
                 all-your-base: 1.0.0.2 == 1.0.0
                         wordy: 1.0.0.2 == 1.0.0
                   minesweeper: 1.0.0.2 == 1.0.0
                scrabble-score: 1.0.0.2 == 1.0.0
                         forth: 1.0.0.2 == 1.0.0
                      dominoes: 1.0.0.2 == 1.0.0
                     raindrops: 1.0.0.2 == 1.0.0
                         clock: 1.0.1.2 == 1.0.1
                    custom-set: 1.0.1.2 == 1.0.1
                     space-age: 1.0.0.2 == 1.0.0
                           say: 1.0.0.2 == 1.0.0
               robot-simulator: 1.0.0.2 == 1.0.0
                  queen-attack: 1.0.0.2 == 1.0.0
                       connect: 1.0.0.2 == 1.0.0
                   ocr-numbers: 1.0.0.2 == 1.0.0
                 prime-factors: 1.0.0.2 == 1.0.0
                     allergies: 1.0.0.2 == 1.0.0
              secret-handshake: 1.0.0.2 == 1.0.0
              sum-of-multiples: 1.0.0.2 == 1.0.0
                 atbash-cipher: 1.0.0.2 == 1.0.0
                     nth-prime: 1.0.0.2 == 1.0.0
                        grains: 1.0.0.2 == 1.0.0
                    word-count: 1.0.0.2 == 1.0.0
              nucleotide-count: 1.0.0.2 == 1.0.0
                         sieve: 1.0.0.2 == 1.0.0
         difference-of-squares: 1.0.0.2 == 1.0.0
             rna-transcription: 1.0.0.2 == 1.0.0
                           bob: 1.0.0.2 == 1.0.0
                   hello-world: 1.0.0.2 == 1.0.0
                           etl: 1.0.0.2 == 1.0.0
                   alphametics: 1.0.0.2 == 1.0.0
                       sublist: 1.0.0.2 == 1.0.0

Exercises updated in this PR not up to date (3):

                  phone-number: 1.0.0.2 -> 1.2.0
                       anagram: 1.0.0.2 -> 1.0.1
                           pov: 1.0.0.2 -> 1.1.1

0.9 exercises that remain out of date (7):

                        change: 0.9.0.1 # 2016-09-17 -> 1.0.0
           run-length-encoding: 0.9.0.1 # 2016-12-26 -> 1.0.0
                          luhn: 0.9.0.1 # 2016-08-04 -> 1.0.0
        largest-series-product: 0.9.0.1 # 2016-07-27 -> 1.0.0
                roman-numerals: 0.9.0.1 # 2016-07-26 -> 1.0.0
                          leap: 0.9.0.1 # 2016-07-27 -> 1.0.0
                       bowling: 0.9.0.1 # 2016-11-20 -> 1.0.0

0.1 exercises not touched by this PR (4):

                 saddle-points: 0.1.0.1 -> 1.0.0
                      list-ops: 0.1.0.1 -> 1.0.0
                      triangle: 0.1.0.1 -> 1.0.0
                 crypto-square: 0.1.0.1 -> 2.0.0

Ignored (8):

                    food-chain: IGNORED: refactoring exercise in Haskell, tests entire song only
                     beer-song: IGNORED: refactoring exercise in Haskell, tests entire song only
                         house: IGNORED: refactoring exercise in Haskell, tests entire song only
                        binary: DEPRECATED
                    gigasecond: DEPRECATED
                       trinary: DEPRECATED
                   hexadecimal: DEPRECATED
                         octal: DEPRECATED

Exercises without JSON file in x-common (20)

           pythagorean-triplet: 0.1.0.1 -> still no JSON file
                   linked-list: 0.1.0.1 -> still no JSON file
           palindrome-products: 0.1.0.1 -> still no JSON file
     parallel-letter-frequency: 0.1.0.1 -> still no JSON file
                  zebra-puzzle: 0.1.0.1 -> still no JSON file
                        zipper: 0.1.0.1 -> still no JSON file
                  grade-school: 0.1.0.1 -> still no JSON file
                   sgf-parsing: 0.1.0.1 -> still no JSON file
                        strain: 0.1.0.1 -> still no JSON file
                        matrix: 0.1.0.1 -> still no JSON file
            binary-search-tree: 0.1.0.1 -> still no JSON file
           kindergarten-garden: 0.1.0.1 -> still no JSON file
                   lens-person: 0.1.0.1 -> still no JSON file
                 simple-cipher: 0.1.0.1 -> still no JSON file
                  bank-account: 0.1.0.1 -> still no JSON file
                    accumulate: 0.1.0.1 -> still no JSON file
                   go-counting: 0.1.0.1 -> still no JSON file
            simple-linked-list: 0.1.0.1 -> still no JSON file
                        series: 0.1.0.1 -> still no JSON file
                    robot-name: 0.1.0.1 -> still no JSON file

Output generated by https://github.com/petertseng/x-common/blob/up-to-date/up-to-date/haskell.rb
