### PR TITLE
kindergarten-garden 1.0.0.2: edit descriptions and elide middle students

### DIFF
--- a/exercises/kindergarten-garden/package.yaml
+++ b/exercises/kindergarten-garden/package.yaml
@@ -1,5 +1,5 @@
 name: kindergarten-garden
-version: 0.1.0.1
+version: 1.0.0.2
 
 dependencies:
   - base

--- a/exercises/kindergarten-garden/test/Tests.hs
+++ b/exercises/kindergarten-garden/test/Tests.hs
@@ -18,21 +18,21 @@ main = hspecWith defaultConfig {configFastFail = True} specs
 specs :: Spec
 specs = describe "kindergarten-garden" $ do
 
-    it "alice tests" $ do
+    it "garden with single student" $ do
 
       let alicePlants = lookupPlants "Alice" . defaultGarden
 
       alicePlants "RC\nGG" `shouldBe` [ Radishes, Clover, Grass   , Grass  ]
       alicePlants "VC\nRC" `shouldBe` [ Violets , Clover, Radishes, Clover ]
 
-    it "small garden" $ do
+    it "garden with two students" $ do
 
       let plants s  = lookupPlants s $ defaultGarden plantList
           plantList = "VVCG\nVVRC"
 
       plants "Bob" `shouldBe` [ Clover, Grass, Radishes, Clover ]
 
-    it "medium garden" $ do
+    it "garden with three students" $ do
 
       let plants s  = lookupPlants s $ defaultGarden plantList
           plantList = "VVCCGG\nVVCCGG"
@@ -47,18 +47,10 @@ specs = describe "kindergarten-garden" $ do
 
       plants "Alice"   `shouldBe` [ Violets , Radishes, Violets , Radishes ]
       plants "Bob"     `shouldBe` [ Clover  , Grass   , Clover  , Clover   ]
-      plants "Charlie" `shouldBe` [ Violets , Violets , Clover  , Grass    ]
-      plants "David"   `shouldBe` [ Radishes, Violets , Clover  , Radishes ]
-      plants "Eve"     `shouldBe` [ Clover  , Grass   , Radishes, Grass    ]
-      plants "Fred"    `shouldBe` [ Grass   , Clover  , Violets , Clover   ]
-      plants "Ginny"   `shouldBe` [ Clover  , Grass   , Grass   , Clover   ]
-      plants "Harriet" `shouldBe` [ Violets , Radishes, Radishes, Violets  ]
-      plants "Ileana"  `shouldBe` [ Grass   , Clover  , Violets , Clover   ]
-      plants "Joseph"  `shouldBe` [ Violets , Clover  , Violets , Grass    ]
       plants "Kincaid" `shouldBe` [ Grass   , Clover  , Clover  , Grass    ]
       plants "Larry"   `shouldBe` [ Grass   , Violets , Clover  , Violets  ]
 
-    it  "surprise garden" $ do
+    it  "non-alphabetical student list" $ do
 
       let plants s  = lookupPlants s $ garden students plantList
           plantList = "VCRRGVRG\nRVGCCGCV"


### PR DESCRIPTION
Descriptions are clearer as to the significance of the garden size, or
the fact that the given student list is non-alphabetical.

The tests of the middle children in the full garden are elided.

The canonical data file was added in https://github.com/exercism/x-common/pull/770