### PR TITLE
pov 1.1.1.3: simplify "Can find path from nodes other than x"

### DIFF
--- a/exercises/pov/package.yaml
+++ b/exercises/pov/package.yaml
@@ -1,5 +1,5 @@
 name: pov
-version: 1.0.0.2
+version: 1.1.1.3
 
 dependencies:
   - base

--- a/exercises/pov/test/Tests.hs
+++ b/exercises/pov/test/Tests.hs
@@ -68,14 +68,11 @@ specs = describe "pov" $ do
                         , "uncle"
                         , "cousin-1"    ]
 
-      it "Can trace from a leaf to a leaf" $
-        tracePathBetween "kid-a" "cousin-0" cousins
-        `shouldBe` Just [ "kid-a"
-                        , "x"
-                        , "parent"
-                        , "grandparent"
-                        , "uncle"
-                        , "cousin-0"    ]
+      it "Can find path from nodes other than x" $
+        tracePathBetween "a" "c" flat
+        `shouldBe` Just [ "a"
+                        , "root"
+                        , "c"    ]
 
       it "Cannot trace if destination does not exist" $
         tracePathBetween "x" "NOT THERE" cousins


### PR DESCRIPTION
This was the main change in https://github.com/exercism/x-common/pull/704

https://github.com/exercism/x-common/pull/710 is an inconsequential
change that does not affect our tests.

Two other changes in 1.1.0 that aren't exactly followed:

* As a part of conforming to the canonical schema, trees were embedded
  into the test data, but we have no need to do it - let's reduce
  duplication, and besides we are safe from accidental mutation.
* The "cannot trace" cases were changed to use simpler trees than
  cousins, but we would have had to introduce another tree to do that
  (one with kids and siblings). We'll stick with cousins.