### PR TITLE
dominoes 1.0.1.3: correctly declare nine elements in largest case

### DIFF
--- a/exercises/dominoes/package.yaml
+++ b/exercises/dominoes/package.yaml
@@ -1,5 +1,5 @@
 name: dominoes
-version: 1.0.0.2
+version: 1.0.1.3
 
 dependencies:
   - base

--- a/exercises/dominoes/test/Tests.hs
+++ b/exercises/dominoes/test/Tests.hs
@@ -99,7 +99,7 @@ cases = [ Case { description = "empty input = empty output"
                , input       = [(1, 2), (2, 3), (3, 1), (1, 1), (2, 2), (3, 3)]
                , expected    = True
                }
-        , Case { description = "ten elements"
+        , Case { description = "nine elements"
                , input       = [(1, 2), (5, 3), (3, 1), (1, 2), (2, 4), (1, 6), (2, 3), (3, 4), (5, 6)]
                , expected    = True
                }


### PR DESCRIPTION
There have always been nine elements, ever since the origin of this test
in https://github.com/exercism/xrust/pull/13#discussion_r115148635

The description incorrectly claimed ten.

https://github.com/exercism/x-common/pull/777