### PR TITLE
change: Remove test groups not matching x-common

### DIFF
--- a/exercises/change/package.yaml
+++ b/exercises/change/package.yaml
@@ -1,5 +1,5 @@
 name: change
-version: 1.0.0.2
+version: 1.0.0.3
 
 dependencies:
   - base

--- a/exercises/change/test/Tests.hs
+++ b/exercises/change/test/Tests.hs
@@ -2,7 +2,7 @@
 
 import Data.Foldable     (for_)
 import Data.List         (sort)
-import Test.Hspec        (Spec, describe, it, shouldBe)
+import Test.Hspec        (Spec, it, shouldBe)
 import Test.Hspec.Runner (configFastFail, defaultConfig, hspecWith)
 
 import Change (findFewestCoins)
@@ -11,8 +11,7 @@ main :: IO ()
 main = hspecWith defaultConfig {configFastFail = True} specs
 
 specs :: Spec
-specs = describe "Change" $
-          describe "change" $ for_ cases test
+specs = for_ cases test
   where
 
     test Case{..} = it description assertion


### PR DESCRIPTION
Reference test data has no test groups, so we remove the unneeded two levels of nesting.

Note that the exercise's name is always automatically displayed when running the tests suite.