### PR TITLE
parallel-letter-frequency: Add benchmark

### DIFF
--- a/exercises/parallel-letter-frequency/HINTS.md
+++ b/exercises/parallel-letter-frequency/HINTS.md
@@ -3,3 +3,7 @@
 Your code should contain a frequency :: Int -> [Text] -> Map Char Int
 function which accepts a number of workers to use in parallel and a list
 of texts and returns the total frequency of each letter in the text.
+
+### Benchmark
+
+Check how changing number of workers affects performance of your solution by running the benchmark. Use `stack bench` to run it. Feel free to modify `bench/Benchmark.hs` to explore your solution's performance on different inputs.

--- a/exercises/parallel-letter-frequency/bench/Benchmark.hs
+++ b/exercises/parallel-letter-frequency/bench/Benchmark.hs
@@ -7,8 +7,7 @@ import Data.Text (Text, unlines)
 
 import Criterion.Main (bench, bgroup, defaultMain, nf)
 import Criterion.Types (Benchmark)
-import Control.Concurrent (setNumCapabilities)
-import GHC.Conc (getNumProcessors)
+import Control.Concurrent (getNumCapabilities)
 import Data.List (nub, sort, replicate)
 
 odeAnDieFreude :: Text
@@ -30,14 +29,12 @@ makeBench anthems workers = bench name $ nf (`frequency` anthems) workers
 
 benchGroup :: Int -> [Int] -> Int -> Benchmark
 benchGroup processors numWorkers numAnthems =
-  bgroup (show numAnthems ++ " anthems on " ++ show processors ++ " cores") (makeBench anthems <$> numWorkers)
+  bgroup (show numAnthems ++ " anthems on " ++ show processors ++ " threads") (makeBench anthems <$> numWorkers)
   where anthems = replicate numAnthems odeAnDieFreude
 
 main :: IO ()
-main = do processors <- getNumProcessors
-          let numsOfWorkers = nub $ sort [1, processors]
+main = do threads <- getNumCapabilities
+          let numsOfWorkers = nub $ sort [1, threads]
               numsOfAnthems = [4, 500]
 
-          -- run on all cores
-          setNumCapabilities processors
-          defaultMain $ benchGroup processors numsOfWorkers <$> numsOfAnthems
+          defaultMain $ benchGroup threads numsOfWorkers <$> numsOfAnthems

--- a/exercises/parallel-letter-frequency/bench/Benchmark.hs
+++ b/exercises/parallel-letter-frequency/bench/Benchmark.hs
@@ -34,7 +34,7 @@ benchGroup processors numWorkers numAnthems =
 
 main :: IO ()
 main = do threads <- getNumCapabilities
-          let numsOfWorkers = nub $ sort [1, threads]
+          let numsOfWorkers = nub $ sort [1..threads]
               numsOfAnthems = [500]
 
           defaultMain $ benchGroup threads numsOfWorkers <$> numsOfAnthems

--- a/exercises/parallel-letter-frequency/bench/Benchmark.hs
+++ b/exercises/parallel-letter-frequency/bench/Benchmark.hs
@@ -33,6 +33,7 @@ benchGroup processors numWorkers numAnthems =
   bgroup (show numAnthems ++ " anthems on " ++ show processors ++ " cores") (makeBench anthems <$> numWorkers)
   where anthems = replicate numAnthems odeAnDieFreude
 
+main :: IO ()
 main = do processors <- getNumProcessors
           let numsOfWorkers = nub $ sort [1, processors]
               numsOfAnthems = [4, 500]

--- a/exercises/parallel-letter-frequency/bench/Benchmark.hs
+++ b/exercises/parallel-letter-frequency/bench/Benchmark.hs
@@ -1,0 +1,46 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+import Frequency (frequency)
+
+import Prelude hiding (unlines)
+import Data.Text (Text, unlines)
+
+import Criterion.Main (bench, bgroup, defaultMain, nf)
+import Criterion.Types (Benchmark)
+import Control.Concurrent (setNumCapabilities)
+import GHC.Conc (getNumProcessors)
+import Data.List (nub, sort, replicate)
+
+odeAnDieFreude :: Text
+odeAnDieFreude = unlines
+                 [ "Freude schöner Götterfunken"
+                 , "Tochter aus Elysium,"
+                 , "Wir betreten feuertrunken,"
+                 , "Himmlische, dein Heiligtum!"
+                 , "Deine Zauber binden wieder"
+                 , "Was die Mode streng geteilt;"
+                 , "Alle Menschen werden Brüder,"
+                 , "Wo dein sanfter Flügel weilt."
+                 ]
+
+
+makeBench :: [Text] -> Int -> Benchmark
+makeBench anthems workers = bench name $ nf (`frequency` anthems) workers
+  where name = show workers ++ " workers"
+
+benchGroup :: Int -> [Int] -> Int -> Benchmark
+benchGroup processors numWorkers numAnthems =
+  bgroup (show numAnthems ++ " anthems on " ++ show processors ++ " cores") (makeBench anthems <$> numWorkers)
+  where anthems = replicate numAnthems odeAnDieFreude
+
+main = do processors <- getNumProcessors
+          let numsOfWorkers = nub $ sort [1, processors]
+              numsOfAnthems = [4, 500]
+
+          -- run on 1 core
+          setNumCapabilities 1
+          defaultMain $ benchGroup 1 numsOfWorkers <$> numsOfAnthems
+
+          -- run on all cores
+          setNumCapabilities processors
+          defaultMain $ benchGroup processors numsOfWorkers <$> numsOfAnthems

--- a/exercises/parallel-letter-frequency/bench/Benchmark.hs
+++ b/exercises/parallel-letter-frequency/bench/Benchmark.hs
@@ -38,10 +38,6 @@ main = do processors <- getNumProcessors
           let numsOfWorkers = nub $ sort [1, processors]
               numsOfAnthems = [4, 500]
 
-          -- run on 1 core
-          setNumCapabilities 1
-          defaultMain $ benchGroup 1 numsOfWorkers <$> numsOfAnthems
-
           -- run on all cores
           setNumCapabilities processors
           defaultMain $ benchGroup processors numsOfWorkers <$> numsOfAnthems

--- a/exercises/parallel-letter-frequency/bench/Benchmark.hs
+++ b/exercises/parallel-letter-frequency/bench/Benchmark.hs
@@ -35,6 +35,6 @@ benchGroup processors numWorkers numAnthems =
 main :: IO ()
 main = do threads <- getNumCapabilities
           let numsOfWorkers = nub $ sort [1, threads]
-              numsOfAnthems = [4, 500]
+              numsOfAnthems = [500]
 
           defaultMain $ benchGroup threads numsOfWorkers <$> numsOfAnthems

--- a/exercises/parallel-letter-frequency/examples/success-standard/package.yaml
+++ b/exercises/parallel-letter-frequency/examples/success-standard/package.yaml
@@ -1,7 +1,5 @@
 name: parallel-letter-frequency
 
-ghc-options: -threaded -with-rtsopts=-N -O2
-
 dependencies:
   - base
   - containers
@@ -23,6 +21,8 @@ tests:
 
 benchmarks:
   bench:
+    ghc-options: -threaded -with-rtsopts=-N -O2
+
     main: Benchmark.hs
     source-dirs: bench
     dependencies:

--- a/exercises/parallel-letter-frequency/examples/success-standard/package.yaml
+++ b/exercises/parallel-letter-frequency/examples/success-standard/package.yaml
@@ -22,7 +22,7 @@ tests:
 
 benchmarks:
   bench:
-    main: Benchmarks.hs
+    main: Benchmark.hs
     source-dirs: bench
     dependencies:
       - parallel-letter-frequency

--- a/exercises/parallel-letter-frequency/examples/success-standard/package.yaml
+++ b/exercises/parallel-letter-frequency/examples/success-standard/package.yaml
@@ -1,4 +1,5 @@
 name: parallel-letter-frequency
+version: 0.1.0.3
 
 dependencies:
   - base
@@ -18,3 +19,11 @@ tests:
     dependencies:
       - parallel-letter-frequency
       - hspec
+
+benchmarks:
+  bench:
+    main: Benchmarks.hs
+    source-dirs: bench
+    dependencies:
+      - parallel-letter-frequency
+      - criterion

--- a/exercises/parallel-letter-frequency/examples/success-standard/package.yaml
+++ b/exercises/parallel-letter-frequency/examples/success-standard/package.yaml
@@ -1,5 +1,7 @@
 name: parallel-letter-frequency
 
+ghc-options: -threaded -rtsopts -O2
+
 dependencies:
   - base
   - containers

--- a/exercises/parallel-letter-frequency/examples/success-standard/package.yaml
+++ b/exercises/parallel-letter-frequency/examples/success-standard/package.yaml
@@ -1,5 +1,4 @@
 name: parallel-letter-frequency
-version: 0.1.0.3
 
 dependencies:
   - base

--- a/exercises/parallel-letter-frequency/examples/success-standard/package.yaml
+++ b/exercises/parallel-letter-frequency/examples/success-standard/package.yaml
@@ -1,6 +1,6 @@
 name: parallel-letter-frequency
 
-ghc-options: -threaded -rtsopts -O2
+ghc-options: -threaded -with-rtsopts=-N -O2
 
 dependencies:
   - base

--- a/exercises/parallel-letter-frequency/package.yaml
+++ b/exercises/parallel-letter-frequency/package.yaml
@@ -1,6 +1,8 @@
 name: parallel-letter-frequency
 version: 0.1.0.3
 
+ghc-options: -threaded -rtsopts -O2
+
 dependencies:
   - base
   - containers

--- a/exercises/parallel-letter-frequency/package.yaml
+++ b/exercises/parallel-letter-frequency/package.yaml
@@ -1,7 +1,7 @@
 name: parallel-letter-frequency
 version: 0.1.0.3
 
-ghc-options: -threaded -rtsopts -O2
+ghc-options: -threaded -with-rtsopts=-N -O2
 
 dependencies:
   - base

--- a/exercises/parallel-letter-frequency/package.yaml
+++ b/exercises/parallel-letter-frequency/package.yaml
@@ -1,5 +1,5 @@
 name: parallel-letter-frequency
-version: 0.1.0.2
+version: 0.1.0.3
 
 dependencies:
   - base
@@ -20,3 +20,11 @@ tests:
     dependencies:
       - parallel-letter-frequency
       - hspec
+
+benchmarks:
+  bench:
+    main: Benchmarks.hs
+    source-dirs: bench
+    dependencies:
+      - parallel-letter-frequency
+      - criterion

--- a/exercises/parallel-letter-frequency/package.yaml
+++ b/exercises/parallel-letter-frequency/package.yaml
@@ -23,7 +23,7 @@ tests:
 
 benchmarks:
   bench:
-    main: Benchmarks.hs
+    main: Benchmark.hs
     source-dirs: bench
     dependencies:
       - parallel-letter-frequency

--- a/exercises/parallel-letter-frequency/package.yaml
+++ b/exercises/parallel-letter-frequency/package.yaml
@@ -1,8 +1,6 @@
 name: parallel-letter-frequency
 version: 0.1.0.3
 
-ghc-options: -threaded -with-rtsopts=-N -O2
-
 dependencies:
   - base
   - containers
@@ -25,6 +23,8 @@ tests:
 
 benchmarks:
   bench:
+    ghc-options: -threaded -with-rtsopts=-N -O2
+
     main: Benchmark.hs
     source-dirs: bench
     dependencies:


### PR DESCRIPTION
Fixes https://github.com/exercism/xhaskell/issues/519

I've added a benchmark test that makes sure that `frequency` function runs at least 10% faster (arbitrary number) with multiple workers that with a single worker.

It increases the time it takes to run the tests by about 5 seconds on my machine, not sure if it's acceptable. It might be possible to make it faster by tweaking Criterion settings.

Another concern is the benchmark test would only work correctly on a machine with at least 2 cores.

It prints the benchmark results into the console:

```
frequency
  no texts mean no letters
  one letter
  case insensitivity
  many empty texts still mean no letters
  many times the same text gives a predictable result
  punctuation doesn't count
  numbers don't count
  all three anthems, together, 1 worker
  all three anthems, together, 4 workers
Run with a single worker
benchmarking...
time                 4.487 ms   (4.398 ms .. 4.544 ms)
                     0.999 R²   (0.998 R² .. 1.000 R²)
mean                 4.566 ms   (4.557 ms .. 4.577 ms)
std dev              17.05 μs   (11.71 μs .. 25.01 μs)

Run with 4 workers
benchmarking...
time                 1.425 ms   (1.345 ms .. 1.490 ms)
                     0.977 R²   (0.951 R² .. 0.992 R²)
mean                 1.556 ms   (1.539 ms .. 1.585 ms)
std dev              50.19 μs   (33.35 μs .. 71.29 μs)
variance introduced by outliers: 13% (moderately inflated)

  multiple workers run faster than 1

Finished in 4.9143 seconds
10 examples, 0 failures

```

I guess another option would be to add a separate benchmark and have users check the speed themselves, not sure which option is better. If it looks good I'm going to add some information about it into `HINTS.md`. 

Maybe we could make it optional somehow?