### PR TITLE
matrix: Remove string tests

### DIFF
--- a/exercises/matrix/test/Tests.hs
+++ b/exercises/matrix/test/Tests.hs
@@ -69,16 +69,3 @@ specs = do
 
     it "flatten" $
       flatten (intMatrix "1 2\n3 4") `shouldBe` vector [1, 2, 3, 4]
-
-    it "matrix of chars" $
-      fromString "'f' 'o' 'o'\n'b' 'a' 'r'" `shouldBe` fromList ["foo", "bar"]
-
-    it "matrix of strings" $ 
-       fromString "\"this one\"\n\"may be tricky!\""
-       `shouldBe` fromList [ ["this one"      ]
-                           , ["may be tricky!"] ]
-
-    it "matrix of strings 2" $ 
-       fromString "\"this one\" \"one\" \n\"may be tricky!\" \"really tricky\""
-       `shouldBe` fromList [ ["this one"      , "one"          ]
-                           , ["may be tricky!", "really tricky"] ]


### PR DESCRIPTION
~~It was argued in #541 that the the exercise would be more interesting without the `fromString` function, which is not an essential part of of it.~~

- ~~Rewrite test suite to use `[[Int]]` instead of `String`.~~
- ~~Remove test that wouldn't make sense without `fromString`.~~
- ~~Remove all other references to `fromString`.~~
- ~~Fix `HINTS.md` to remove reference to invalid characters.~~

---

**Edit**:

The scope of this PR was restricted to just removing the last three tests, based on the discussion below. If in the future we decided to completely remove `fromString` from the test suite, `description.md` will demand some rewriting.

I think that it is preferable to completely rewrite or remove this exercise. The way it is now is lacks focus and also exposes users to a really unidiomatic interface.

---

Closes #541.