### PR TITLE
difference-of-squares 1.1.0.4: Test 1, 5, 100 for all functions

### DIFF
--- a/exercises/difference-of-squares/package.yaml
+++ b/exercises/difference-of-squares/package.yaml
@@ -1,5 +1,5 @@
 name: difference-of-squares
-version: 1.0.0.3
+version: 1.1.0.4
 
 dependencies:
   - base

--- a/exercises/difference-of-squares/test/Tests.hs
+++ b/exercises/difference-of-squares/test/Tests.hs
@@ -12,19 +12,18 @@ specs :: Spec
 specs = do
 
     describe "squareOfSums" $ do
+      it "square of sum 1"   $ squareOfSums   1 `shouldBe`        1
       it "square of sum 5"   $ squareOfSums   5 `shouldBe`      225
-      it "square of sum 10"  $ squareOfSums  10 `shouldBe`     3025
       it "square of sum 100" $ squareOfSums 100 `shouldBe` 25502500
 
     describe "sumOfSquares" $ do
+      it "sum of squares 1"   $ sumOfSquares   1 `shouldBe`      1
       it "sum of squares 5"   $ sumOfSquares   5 `shouldBe`     55
-      it "sum of squares 10"  $ sumOfSquares  10 `shouldBe`    385
       it "sum of squares 100" $ sumOfSquares 100 `shouldBe` 338350
 
     describe "differenceOfSquares" $ do
-      it "difference of squares 0"   $ difference   0 `shouldBe`        0
+      it "difference of squares 1"   $ difference   1 `shouldBe`        0
       it "difference of squares 5"   $ difference   5 `shouldBe`      170
-      it "difference of squares 10"  $ difference  10 `shouldBe`     2640
       it "difference of squares 100" $ difference 100 `shouldBe` 25164150
 
     -- Track-specific tests.


### PR DESCRIPTION
Tests for 10 are removed, tests for 1 are added, and the test for
`difference 0` was removed.

https://github.com/exercism/x-common/pull/791