### PR TITLE
travis: Increase cache upload timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ addons:
       - libgmp-dev       # Stack's GHC depends on this.
 
 cache:
+  timeout: 600           # The cache is too big to upload in 180 seconds.
   directories:
     - $HOME/.stack       # Global stack's cache.
     - $HOME/.foldercache # Per exercise `.stack-work` cache.


### PR DESCRIPTION
- Raise cache upload timeout from 180 to 600.

As the Travis-CI tests gets more complex, the amount of cache needed to rebuild it efficiently also increases. Now we reached a situation where it is sometimes too big to be uploaded in time.

```
uploading archive
running `casher push` took longer than 180 seconds and has been aborted
Done. Your build exited with 0.
```

While this doesn't fail the tests, it makes reviewing PRs painfully slow.