### PR TITLE
travis: Remove error-type examples's cache

### DIFF
--- a/bin/test-example
+++ b/bin/test-example
@@ -66,6 +66,8 @@ elif [ "$exampletype" = "error" ]; then
     if runstack "test" "--no-run-tests"; then
         echo "${exampledir} build succeeded unexpectedly"
         exit 1
+    else
+        rm -rf "${examplecache}"
     fi
 else
     echo "unknown example type: ${exampledir}"


### PR DESCRIPTION
Exercise's examples that are always expected to fail the building step are rebuilt by Stack everytime. This triggers a cache update in Travis-CI, even when nothing changed in the repository.

While this problem doesn't affect pull requests that already change the cache, it slows down the all the other PRs by sometimes around 3 minutes.

Removing the cache folder for error-type examples, we expect to have clean rebuilds in Travis.

Closes #544.