### PR TITLE
travis: Build exercise's benchmarks

### DIFF
--- a/bin/test-example
+++ b/bin/test-example
@@ -22,7 +22,13 @@ cleanup() {
 }
 trap cleanup EXIT INT TERM
 
-cp -R -L ${exercisedir}/stack.yaml ${exercisedir}/test ${exampledir}/* "${buildfolder}"
+cp -R -L                      \
+    ${exercisedir}/stack.yaml \
+    ${exercisedir}/test       \
+    ${exercisedir}/bench      \
+    ${exampledir}/*           \
+    "${buildfolder}"          \
+    2> /dev/null || true # Suppress the error, if missing 'bench'.
 
 cd $buildfolder
 
@@ -39,10 +45,12 @@ exampletype=$(echo "$examplename" | cut -d- -f1)
 
 runstack () {
     # SET_RESOLVER passed by .travis.yml - sets --resolver if not current.
-    stack "$@" ${SET_RESOLVER} `# Select the correct resolver. `\
-               --install-ghc   `# Download GHC if not in cache.`\
-               --no-terminal   `# Terminal detection is broken.`\
-               --pedantic      `# Enable -Wall and -Werror.    `
+    stack "$@" ${SET_RESOLVER}     `# Select the correct resolver. `\
+               --install-ghc       `# Download GHC if not in cache.`\
+               --no-terminal       `# Terminal detection is broken.`\
+               --bench             `# Build benchmarks, but        `\
+               --no-run-benchmarks `# do not run them.             `\
+               --pedantic          `# Enable -Wall and -Werror.    `
 }
 
 if [ "$exampletype" = "success" ]; then

--- a/bin/test-stub
+++ b/bin/test-stub
@@ -20,7 +20,14 @@ cleanup() {
 }
 trap cleanup EXIT INT TERM
 
-cp -R -L ${exercisedir}/stack.yaml ${exercisedir}/package.yaml ${exercisedir}/src ${exercisedir}/test "${buildfolder}"
+cp -R -L                        \
+    ${exercisedir}/stack.yaml   \
+    ${exercisedir}/package.yaml \
+    ${exercisedir}/src          \
+    ${exercisedir}/test         \
+    ${exercisedir}/bench        \
+    "${buildfolder}"            \
+    2> /dev/null || true # Suppress the error, if missing 'bench'.
 
 cd $buildfolder
 
@@ -38,6 +45,8 @@ if [ -f "${exercisedir}/.meta/DONT-TEST-STUB" ]; then
     echo "only building stub"
     stack build ${SET_RESOLVER} --install-ghc --no-terminal
 else
-    echo "testing stub"
-    stack test ${SET_RESOLVER} --install-ghc --no-terminal --no-run-tests
+    echo "building stub with everything else"
+    stack build ${SET_RESOLVER} --install-ghc --no-terminal \
+                --test  --no-run-tests                      \
+                --bench --no-run-benchmarks
 fi


### PR DESCRIPTION
- Enable building benchmarks when testing the exercises.

While it is undesirable to run benchmarks as part of the tests, checking that the stubs and example solutions can compile with them is needed to assure that the user will be able to run the benchmarks.