### PR TITLE
test-scripts: Fix benchmark folder copy

### DIFF
--- a/bin/test-example
+++ b/bin/test-example
@@ -25,10 +25,12 @@ trap cleanup EXIT INT TERM
 cp -R -L                      \
     ${exercisedir}/stack.yaml \
     ${exercisedir}/test       \
-    ${exercisedir}/bench      \
     ${exampledir}/*           \
-    "${buildfolder}"          \
-    2> /dev/null || true # Suppress the error, if missing 'bench'.
+    "${buildfolder}"
+
+if [ -d ${exercisedir}/bench ]; then
+    cp -R -L ${exercisedir}/bench "${buildfolder}"
+fi
 
 cd $buildfolder
 

--- a/bin/test-stub
+++ b/bin/test-stub
@@ -25,9 +25,11 @@ cp -R -L                        \
     ${exercisedir}/package.yaml \
     ${exercisedir}/src          \
     ${exercisedir}/test         \
-    ${exercisedir}/bench        \
-    "${buildfolder}"            \
-    2> /dev/null || true # Suppress the error, if missing 'bench'.
+    "${buildfolder}"
+
+if [ -d ${exercisedir}/bench ]; then
+    cp -R -L ${exercisedir}/bench "${buildfolder}"
+fi
 
 cd $buildfolder
 


### PR DESCRIPTION
To address @petertseng's concern: 😁 

> It's a shame that we'll no longer error on the cp if, say, a stack.yaml is missing, but I guess it's OK that the error happens later.

Sorry for not fixing that in #552.